### PR TITLE
Just assume prettier api won't change until 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint": "^3.17.0",
     "indent-string": "^3.1.0",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "prettier": "^0.22.0",
+    "prettier": "<1.0.0",
     "pretty-format": "^19.0.0",
     "require-relative": "^0.8.7"
   },


### PR DESCRIPTION
It avoids unnecessary commits and makes prettier-eslint always up-to-date with regard to prettier

In worst case, if API breaks, you can release a quick patch