### PR TITLE
fix: Allow for no presence of .eslintrc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,8 +188,8 @@ function getConfig(filePath, eslintPath) {
     return config
   } catch (error) {
     // is this noisy? Try setting options.disableLog to false
-    logger.error('Unable to find config')
-    throw error
+    logger.warn('Unable to find config')
+    return { rules: {} }
   }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -124,15 +124,6 @@ tests.forEach(({title, modifier, input, output}) => {
   })
 })
 
-test('failure to get the config throws and logs an error', () => {
-  const {getConfigForFile} = eslintMock.mock
-  const error = 'Something happened'
-  getConfigForFile.throwError = new Error(error)
-  expect(() => format({text: ''})).toThrowError(error)
-  expect(logger.error).toHaveBeenCalledTimes(1)
-  getConfigForFile.throwError = null
-})
-
 test('failure to fix with eslint throws and logs an error', () => {
   const {executeOnText} = eslintMock.mock
   const error = 'Something happened'
@@ -240,7 +231,8 @@ test('reads text from fs if filePath is provided but not text', () => {
   } catch (e) {
     // ignore
   }
-  expect(fsMock.readFileSync).toHaveBeenCalledTimes(1)
+  // Two hits to .eslintignore
+  expect(fsMock.readFileSync).toHaveBeenCalledTimes(3)
   expect(fsMock.readFileSync).toHaveBeenCalledWith(filePath, 'utf8')
 })
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -63,6 +63,11 @@ const defaultEslintConfigTests = [
     },
   },
   {
+    config: undefined,
+    defaults: undefined,
+    result: {},
+  },
+  {
     config: {},
     defaults: {},
     result: {},


### PR DESCRIPTION
This fixes #51 because after it we try to read eslint config even if eslintConfig is provided.
Unfortunately it also means eslint will crash if .eslintrc is not present. This change makes
.eslintrc presence optional.