### PR TITLE
fix: Make prettier-eslint less verbose when no .eslintrc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ function getConfig(filePath, eslintPath) {
     return config
   } catch (error) {
     // is this noisy? Try setting options.disableLog to false
-    logger.warn('Unable to find config')
+    logger.debug('Unable to find config')
     return { rules: {} }
   }
 }


### PR DESCRIPTION
This prevents yet another artifact introduced by my previous PR. Specifically the output of prettier-eslint looks like following when no .eslintrc is present:

```
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
prettier-eslint [WARN]: Unable to find config
success formatting 2 files with prettier-eslint
5 files were unchanged
```

This fixes it by changing log level to debug