### PR TITLE
fix: trailingComma all only if functions enabled

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -161,7 +161,7 @@ function getTrailingComma(value, rules) {
     }
   }
 
-  return value === 'never' ? 'none' : 'all'
+  return value === 'never' ? 'none' : 'es5'
 
   function getValFromObjectConfig(eslintValue) {
     const [, {arrays, objects, functions}] = eslintValue

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -120,7 +120,22 @@ const getPrettierOptionsFromESLintRulesTests = [
   },
   {rules: {'max-len': 2}, options: {printWidth: 80}},
   {rules: {'comma-dangle': [2, 'never']}, options: {trailingComma: 'none'}},
-  {rules: {'comma-dangle': [2, 'always']}, options: {trailingComma: 'all'}},
+  {rules: {'comma-dangle': [2, 'always']}, options: {trailingComma: 'es5'}},
+  {
+    rules: {
+      'comma-dangle': [
+        2,
+        {
+          arrays: 'always-multiline',
+          objects: 'always-multiline',
+          imports: 'always-multiline',
+          exports: 'always-multiline',
+          functions: 'always-multiline',
+        },
+      ],
+    },
+    options: {trailingComma: 'all'},
+  },
   {
     rules: {
       'comma-dangle': [


### PR DESCRIPTION
This is in line with eslint's defaults for string values: http://eslint.org/docs/rules/comma-dangle.

Fixes https://github.com/prettier/prettier-eslint/issues/69.