### PR TITLE
feat: upgrade prettier to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "indent-string": "^3.1.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "prettier": "^1.0.2",
+    "prettier": "^1.3.0",
     "pretty-format": "^19.0.0",
     "require-relative": "^0.8.7"
   },

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -208,21 +208,18 @@ defaultEslintConfigTests.forEach(({config, defaults, result}, index) => {
   })
 })
 
-getPrettierOptionsFromESLintRulesTests.forEach(({
-  rules,
-  options,
-  prettierOptions,
-  fallbackPrettierOptions,
-}, index) => {
-  test(`getPrettierOptionsFromESLintRulesTests ${index}`, () => {
-    const {prettier} = getOptionsForFormatting(
-      {rules},
-      prettierOptions,
-      fallbackPrettierOptions,
-    )
-    expect(prettier).toMatchObject(options)
-  })
-})
+getPrettierOptionsFromESLintRulesTests.forEach(
+  ({rules, options, prettierOptions, fallbackPrettierOptions}, index) => {
+    test(`getPrettierOptionsFromESLintRulesTests ${index}`, () => {
+      const {prettier} = getOptionsForFormatting(
+        {rules},
+        prettierOptions,
+        fallbackPrettierOptions,
+      )
+      expect(prettier).toMatchObject(options)
+    })
+  },
+)
 
 test('if prettierOptions are provided, those are preferred', () => {
   const {prettier} = getOptionsForFormatting(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,9 +2295,9 @@ flow-parser@0.40.0:
     colors ">=0.6.2"
     minimist ">=0.2.0"
 
-flow-parser@0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
+flow-parser@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.45.0.tgz#aa29d4ae27f06aa02817772bba0fcbefef7e62f0"
 
 follow-redirects@0.0.7:
   version "0.0.7"
@@ -4354,16 +4354,16 @@ prettier@^0.22.0:
     jest-validate "19.0.0"
     minimist "1.2.0"
 
-prettier@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.0.2.tgz#84535548fca00cf0acd7ca8296d492352ef167d7"
+prettier@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.3.0.tgz#cb02314f1ae2a99e951c17acb77a4096a1060ac2"
   dependencies:
     ast-types "0.9.8"
     babel-code-frame "6.22.0"
     babylon "7.0.0-beta.8"
     chalk "1.1.3"
     esutils "2.0.2"
-    flow-parser "0.43.0"
+    flow-parser "0.45.0"
     get-stdin "5.0.1"
     glob "7.1.1"
     jest-validate "19.0.0"


### PR DESCRIPTION
Hello !

As there have been some minor changes in prettier, this PR upgrades **prettier** to **1.3.0** ! Also ran fix which only generated change in : `src/utils.test.js`

If I can improve this PR, I'll be glad to do so 😄 !