### PR TITLE
Correct Prettier defaults

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -120,8 +120,10 @@ const tests = [
   // go ahead and add a test case here
   {
     title: 'with code that needs no fixing',
-    input: {text: 'var [foo, {bar}] = window.APP;', eslintConfig: {rules: {}}},
-    output: 'var [foo, {bar}] = window.APP;',
+    input: {
+      text: 'var [foo, { bar }] = window.APP;', eslintConfig: {rules: {}},
+    },
+    output: 'var [foo, { bar }] = window.APP;',
   },
 ]
 
@@ -307,7 +309,7 @@ function noopOutput() {
   return `
     function foo() {
       // stuff
-      console.log('Hello world!', and, stuff);
+      console.log("Hello world!", and, stuff);
     }
   `
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -195,7 +195,7 @@ function getSingleQuote(eslintValue, fallbacks) {
     prettierValue = eslintValue
   }
 
-  return makePrettierOption('singleQuote', prettierValue, fallbacks, true)
+  return makePrettierOption('singleQuote', prettierValue, fallbacks, false)
 }
 
 function getTrailingComma(value, fallbacks, rules) {
@@ -212,7 +212,7 @@ function getTrailingComma(value, fallbacks, rules) {
     prettierValue = RULE_NOT_CONFIGURED
   }
 
-  return makePrettierOption('trailingComma', prettierValue, fallbacks, 'es5')
+  return makePrettierOption('trailingComma', prettierValue, fallbacks, 'none')
 }
 
 function getValFromTrailingCommaConfig(objectConfig) {
@@ -240,7 +240,7 @@ function getBracketSpacing(eslintValue, fallbacks) {
     prettierValue = eslintValue
   }
 
-  return makePrettierOption('bracketSpacing', prettierValue, fallbacks, false)
+  return makePrettierOption('bracketSpacing', prettierValue, fallbacks, true)
 }
 
 function getSemi(eslintValue, fallbacks) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -100,6 +100,7 @@ const getPrettierOptionsFromESLintRulesTests = [
           functions: 'always-multiline',
         },
       ],
+      'object-curly-spacing': [2, 'never'],
     },
     options: {
       printWidth: 120,


### PR DESCRIPTION
The defaultValue param's are not matching Prettier's defaults in these lines:
- https://github.com/prettier/prettier-eslint/blob/master/src/utils.js#L198 (should be `false`)
- https://github.com/prettier/prettier-eslint/blob/master/src/utils.js#L215 (should be 'none') 
- https://github.com/prettier/prettier-eslint/blob/master/src/utils.js#L243 (should be `true`)

This PR fixes this.