### PR TITLE
options.eslintConfig is an object, not a string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports = format
  *   Will default to require.resolve('eslint')
  * @param {String} options.prettierPath - the path to the prettier module.
  *   Will default to require.resovlve('prettierPath')
- * @param {String} options.eslintConfig - the config to use for formatting
+ * @param {Object} options.eslintConfig - the config to use for formatting
  *  with ESLint.
  * @param {Object} options.prettierOptions - the options to pass for
  *  formatting with `prettier`. If not provided, prettier-eslint will attempt


### PR DESCRIPTION
According to https://github.com/prettier/prettier-eslint/blob/bee9283f005fda2b08d1940f4455169333effa07/src/utils.js#L47