### PR TITLE
feat: support prettier configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,8 @@
       {
         "targets": {
           "node": "4.5"
-        }
+        },
+        "exclude": ["transform-regenerator"]
       }
     ]
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,13 @@
   ],
   "rules": {
     "valid-jsdoc": "off",
-    "max-len": "off"
+    "max-len": "off",
+    "semi": "off",
+    "quotes": "off",
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
   "name": "prettier-eslint",
   "version": "0.0.0-development",
-  "description": "Formats your JavaScript using prettier followed by eslint --fix",
+  "description":
+    "Formats your JavaScript using prettier followed by eslint --fix",
   "main": "dist/index.js",
   "scripts": {
     "start": "nps",
     "test": "nps test",
     "precommit": "opt --in pre-commit --exec \"npm start validate\""
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",

--- a/src/__mocks__/eslint.js
+++ b/src/__mocks__/eslint.js
@@ -9,7 +9,7 @@ mockGetConfigForFileSpy.overrides = {}
 const mockExecuteOnTextSpy = jest.fn(mockExecuteOnText)
 
 module.exports = Object.assign(eslint, {
-  CLIEngine: MockCLIEngine,
+  CLIEngine: jest.fn(MockCLIEngine),
   mock: {
     getConfigForFile: mockGetConfigForFileSpy,
     executeOnText: mockExecuteOnTextSpy,
@@ -27,6 +27,7 @@ function MockCLIEngine(...args) {
 
 MockCLIEngine.prototype = Object.create(CLIEngine.prototype)
 
+// eslint-disable-next-line complexity
 function mockGetConfigForFile(filePath) {
   if (mockGetConfigForFileSpy.throwError) {
     throw mockGetConfigForFileSpy.throwError
@@ -42,11 +43,7 @@ function mockGetConfigForFile(filePath) {
         semi: [2, 'never'],
         'max-len': [2, 120, 2],
         indent: [2, 2, {SwitchCase: 1}],
-        quotes: [
-          2,
-          'single',
-          {avoidEscape: true, allowTemplateLiterals: true},
-        ],
+        quotes: [2, 'single', {avoidEscape: true, allowTemplateLiterals: true}],
         'comma-dangle': [
           2,
           {

--- a/src/__mocks__/prettier.js
+++ b/src/__mocks__/prettier.js
@@ -5,7 +5,10 @@ module.exports = prettier
 
 const mockFormatSpy = jest.fn(mockFormat)
 
-Object.assign(prettier, {format: mockFormatSpy})
+Object.assign(prettier, {
+  format: mockFormatSpy,
+  resolveConfig: jest.fn(prettier.resolveConfig),
+})
 
 function mockFormat(...args) {
   global.__PRETTIER_ESLINT_TEST_STATE__.prettierPath = __filename

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,96 +1,4 @@
-import {getOptionsForFormatting, defaultEslintConfig} from '../utils'
-
-const defaultEslintConfigTests = [
-  {
-    config: {
-      foo: 'bar',
-      parserOptions: {
-        ecmaVersion: 7,
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
-      rules: {
-        indent: [2, 2, {SwitchCase: 1}],
-        quotes: [
-          2,
-          'single',
-          {avoidEscape: true, allowTemplateLiterals: true},
-        ],
-      },
-      options: {
-        printWidth: 120,
-        tabWidth: 2,
-      },
-    },
-    defaults: {
-      foo: 'not',
-      fiz: 'fuz',
-      parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        ecmaFeatures: {
-          jsx: false,
-          impliedStrict: true,
-        },
-      },
-      rules: {
-        'max-len': [2, 120, 2],
-        indent: [0, 0, {SwitchCase: 0}],
-      },
-      options: {
-        parser: 'babylon',
-        printWidth: 110,
-      },
-    },
-    result: {
-      foo: 'bar',
-      fiz: 'fuz',
-      parserOptions: {
-        ecmaVersion: 7,
-        sourceType: 'module',
-        ecmaFeatures: {
-          jsx: true,
-          impliedStrict: true,
-        },
-      },
-      rules: {
-        'max-len': [2, 120, 2],
-        indent: [2, 2, {SwitchCase: 1}],
-        quotes: [
-          2,
-          'single',
-          {avoidEscape: true, allowTemplateLiterals: true},
-        ],
-      },
-      options: {
-        parser: 'babylon',
-        printWidth: 120,
-        tabWidth: 2,
-      },
-    },
-  },
-  {
-    config: undefined,
-    defaults: undefined,
-    result: {},
-  },
-  {
-    config: {},
-    defaults: {},
-    result: {},
-  },
-  {
-    config: undefined,
-    defaults: {},
-    result: {},
-  },
-  {
-    config: {},
-    defaults: undefined,
-    result: {},
-  },
-]
+import {getOptionsForFormatting} from '../utils'
 
 const getPrettierOptionsFromESLintRulesTests = [
   {
@@ -218,13 +126,6 @@ const getPrettierOptionsFromESLintRulesTests = [
   {rules: {indent: ['error', 'tab']}, options: {useTabs: true}},
   {rules: {indent: [2, 'tab']}, options: {useTabs: true}},
 ]
-
-defaultEslintConfigTests.forEach(({config, defaults, result}, index) => {
-  test(`defaultEslintConfigTests ${index}`, () => {
-    const merged = defaultEslintConfig(config, defaults)
-    expect(merged).toEqual(result)
-  })
-})
 
 getPrettierOptionsFromESLintRulesTests.forEach(
   ({rules, options, prettierOptions, fallbackPrettierOptions}, index) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 import {oneLine} from 'common-tags'
 import delve from 'dlv'
 import getLogger from 'loglevel-colored-level-prefix'
-import merge from 'lodash.merge'
 
 const logger = getLogger({prefix: 'prettier-eslint'})
 const RULE_DISABLED = {}
@@ -42,11 +41,7 @@ const OPTION_GETTERS = {
 }
 
 /* eslint import/prefer-default-export:0 */
-export {getOptionsForFormatting, defaultEslintConfig}
-
-function defaultEslintConfig(eslintConfig = {}, defaultConfig = {}) {
-  return merge({}, defaultConfig, eslintConfig)
-}
+export {getOptionsForFormatting}
 
 function getOptionsForFormatting(
   eslintConfig,

--- a/tests/fixtures/paths/node_modules/prettier/index.js
+++ b/tests/fixtures/paths/node_modules/prettier/index.js
@@ -1,6 +1,6 @@
 const mockPrettier = require('../../../../../src/__mocks__/prettier')
 
-module.exports = {format: mockMockFormat}
+module.exports = Object.assign({}, mockPrettier, {format: mockMockFormat})
 
 function mockMockFormat(...args) {
   try {

--- a/tests/fixtures/paths/package.json
+++ b/tests/fixtures/paths/package.json
@@ -1,5 +1,9 @@
 {
   "eslintConfig": {
     "rules": {}
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
This actually is a partial solution to #118.

BREAKING CHANGE: the API is now async 100% of the time. It's a shame, but we have to do that due to the async nature of resolving the prettier config.

I'd really appreciate a review on this. I'm going to publish a `beta` which you can install with `prettier-eslint@beta`. I'll also publish a beta of `prettier-eslint-cli` soon. Please give it a go!