### PR TITLE
Change prettier config precedence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,8 @@ async function format(options) {
 
   const prettierOptions = merge(
     {},
-    options.prettierOptions,
     await getPrettierConfig(filePath, prettierPath),
+    options.prettierOptions,
   )
 
   const formattingOptions = getOptionsForFormatting(


### PR DESCRIPTION
Prettier options provided to the format function should override
prettier options found in config file.