### PR TITLE
Add basic support for typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "prettier-eslint",
   "version": "0.0.0-development",
-  "description":
-    "Formats your JavaScript using prettier followed by eslint --fix",
+  "description": "Formats your JavaScript using prettier followed by eslint --fix",
   "main": "dist/index.js",
   "scripts": {
     "start": "nps",
     "test": "nps test",
     "precommit": "opt --in pre-commit --exec \"npm start validate\""
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
@@ -22,7 +23,9 @@
     "loglevel-colored-level-prefix": "^1.0.0",
     "prettier": "^1.6.0",
     "pretty-format": "^20.0.3",
-    "require-relative": "^0.8.7"
+    "require-relative": "^0.8.7",
+    "typescript": "^2.4.2",
+    "typescript-eslint-parser": "^7.0.0"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.4.0",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -170,6 +170,14 @@ const tests = [
     },
     output: '{ "foo": "bar" }',
   },
+  {
+    title: 'TypeScript example',
+    input: {
+      text: 'function Foo (this: void) { return this; }',
+      filePath: path.resolve('./test.ts'),
+    },
+    output: 'function Foo(this: void) {\n  return this;\n}',
+  },
 ]
 
 beforeEach(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
-/* eslint complexity: [1, 6] */
+/* eslint complexity: [1, 7] */
 import fs from 'fs'
 import path from 'path'
 import requireRelative from 'require-relative'
@@ -87,12 +87,18 @@ async function format(options) {
 
   const isCss = /\.(css|less|scss)$/.test(filePath)
   const isJson = /\.json$/.test(filePath)
+  const isTypeScript = /\.tsx?$/.test(filePath)
 
   if (isCss) {
     formattingOptions.prettier.parser = 'postcss'
   } else if (isJson) {
     formattingOptions.prettier.parser = 'json'
     formattingOptions.prettier.trailingComma = 'none'
+  } else if (isTypeScript) {
+    formattingOptions.prettier.parser = 'typescript'
+    // XXX: It seems babylon is getting a TypeScript plugin.
+    // Should that be used instead?
+    formattingOptions.eslint.parser = 'typescript-eslint-parser'
   }
 
   const prettify = createPrettify(formattingOptions.prettier, prettierPath)


### PR DESCRIPTION
This should allow `.ts`/`.tsx` files to be run through `prettier` and `eslint` with proper parser settings.