### PR TITLE
feat(format): make format synchronous

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,8 +5,7 @@
       {
         "targets": {
           "node": "4.5"
-        },
-        "exclude": ["transform-regenerator"]
+        }
       }
     ]
   ],

--- a/src/__mocks__/prettier.js
+++ b/src/__mocks__/prettier.js
@@ -7,7 +7,9 @@ const mockFormatSpy = jest.fn(mockFormat)
 
 Object.assign(prettier, {
   format: mockFormatSpy,
-  resolveConfig: jest.fn(prettier.resolveConfig),
+  resolveConfig: {
+    sync: jest.fn(prettier.resolveConfig.sync),
+  },
 })
 
 function mockFormat(...args) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ module.exports = format
  * @param {Boolean} options.prettierLast - Run Prettier Last
  * @return {String} - the formatted string
  */
-async function format(options) {
+function format(options) {
   const {logLevel = getDefaultLogLevel()} = options
   logger.setLevel(logLevel)
   logger.trace('called format with options:', prettyFormat(options))
@@ -61,7 +61,7 @@ async function format(options) {
 
   const prettierOptions = merge(
     {},
-    await getPrettierConfig(filePath, prettierPath),
+    getPrettierConfig(filePath, prettierPath),
     options.prettierOptions,
   )
 
@@ -227,7 +227,7 @@ function getConfig(filePath, eslintPath) {
 
 function getPrettierConfig(filePath, prettierPath) {
   const prettier = requireModule(prettierPath, 'prettier')
-  return prettier.resolveConfig(filePath)
+  return prettier.resolveConfig.sync(filePath)
 }
 
 function requireModule(modulePath, name) {


### PR DESCRIPTION
Prettier's resolveConfig function has a .sync function that doesn't require async handling:
https://github.com/prettier/prettier#prettierresolveconfigfilepath--options