### PR TITLE
Upgrade prettier to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "indent-string": "^3.2.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "prettier": "^1.6.0",
+    "prettier": "^1.7.0",
     "pretty-format": "^20.0.3",
     "require-relative": "^0.8.7",
     "typescript": "^2.4.2",

--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -1,4 +1,8 @@
 const fs = require.requireActual('fs')
 module.exports = Object.assign({}, fs, {
-  readFileSync: jest.fn(() => 'var fake = true'),
+  readFileSync: jest.fn(filename => {
+    return /package\.json$/.test(filename) ?
+      '{"name": "fake", "version": "0.0.0"}' :
+      'var fake = true'
+  }),
 })


### PR DESCRIPTION
Upgrade prettier to [1.7.0](https://github.com/prettier/prettier/issues/2804) to help fix https://github.com/prettier/prettier-eslint-cli/issues/105.

Some tests were (already) failing with:

```
JSONError: JSON Error in /Users/ppvg/github/prettier-eslint/mock/package.json:
Unexpected token 'v' at 1:1
var fake = true
^
```

So the `fs` mock now matches on filename and returns either the original fake or a fake `package.json`. I'm not sure whether that's considered too ugly of a hack.