### PR TITLE
Fix releases path in changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # CHANGELOG
 
 The changelog is automatically updated using [semantic-release](https://github.com/semantic-release/semantic-release).
-You can see it on the [releases page](../releases).
+You can see it on the [releases page](../../releases).


### PR DESCRIPTION
Hi,

current link leads to a 404 while on master.
Those relative links seems pretty fragile actually.