### PR TITLE
fix(backward-compatibility): don't throw if resolveConfig.sync is undefined

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -335,6 +335,24 @@ test('calls prettier.resolveConfig.sync with the file path', () => {
   expect(prettierMock.resolveConfig.sync).toHaveBeenCalledWith(filePath)
 })
 
+test('does not raise an error if prettier.resolveConfig.sync is not defined', () => {
+  const filePath = require.resolve('../../tests/fixtures/paths/foo.js')
+  const originalPrettierMockResolveConfigSync = prettierMock.resolveConfig.sync
+  prettierMock.resolveConfig.sync = undefined
+
+  function callingFormat() {
+    return format({
+      filePath,
+      text: defaultInputText(),
+      eslintConfig: getESLintConfigWithDefaultRules(),
+    })
+  }
+
+  expect(callingFormat).not.toThrowError()
+
+  prettierMock.resolveConfig.sync = originalPrettierMockResolveConfigSync
+})
+
 test('logs if there is a problem making the CLIEngine', () => {
   const error = new Error('fake error')
   eslintMock.CLIEngine.mockImplementation(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -227,7 +227,12 @@ function getConfig(filePath, eslintPath) {
 
 function getPrettierConfig(filePath, prettierPath) {
   const prettier = requireModule(prettierPath, 'prettier')
-  return prettier.resolveConfig.sync(filePath)
+
+  // NOTE: Backward-compatibility with old prettier versions (<1.7)
+  //       that don't have ``resolveConfig.sync` method.
+  return typeof prettier.resolveConfig.sync === 'undefined' ?
+    {} :
+    prettier.resolveConfig.sync(filePath)
 }
 
 function requireModule(modulePath, name) {


### PR DESCRIPTION
Some people still want to use older versions of prettier which does not have the
`resolveConfig.sync` method defined. In this case we will now just pretend like there was a prettier
config but that it was empty.