### PR TITLE
Update typescript-eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "prettier": "^1.7.0",
     "pretty-format": "^20.0.3",
     "require-relative": "^0.8.7",
-    "typescript": "^2.4.2",
-    "typescript-eslint-parser": "^7.0.0"
+    "typescript": "^2.5.1",
+    "typescript-eslint-parser": "^8.0.0"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.4.0",


### PR DESCRIPTION
Update to version 8.0.0, this also required a newer version of typescript.

As this required typescript 2.5.1+ I'm note sure if we should do a minor or major bump of this package, as it might be a breaking change for some people?