### PR TITLE
feat(prettier): Forward all text to prettier

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -185,6 +185,14 @@ const tests = [
       filePath: path.resolve("./test.json")
     },
     output: '{ "foo": "bar" }'
+  },
+  {
+    title: "Markdown example",
+    input: {
+      text: "#   Foo\n _bar_",
+      filePath: path.resolve("./test.md")
+    },
+    output: "# Foo\n\n_bar_"
   }
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,13 +92,15 @@ function format(options) {
     ".ts",
     ".tsx"
   ];
-  const eslintExtensionsRegex = new RegExp(eslintExtensions.join("|"), "gi");
+  const fileExtension = path.extname(filePath || "");
 
   // If we don't get filePath run eslint on text, otherwise only run eslint
   // if it's a configured extension or fall back to a "supported" file type.
-  const onlyPrettier = filePath ? !eslintExtensionsRegex.test(filePath) : false;
+  const onlyPrettier = filePath
+    ? !eslintExtensions.includes(fileExtension)
+    : false;
 
-  if (/\.tsx?$/.test(filePath)) {
+  if ([".ts", ".tsx"].includes(fileExtension)) {
     // XXX: It seems babylon is getting a TypeScript plugin.
     // Should that be used instead?
     formattingOptions.eslint.parser = "typescript-eslint-parser";

--- a/src/index.js
+++ b/src/index.js
@@ -100,16 +100,16 @@ function format(options) {
     ? !eslintExtensions.includes(fileExtension)
     : false;
 
-  if ([".ts", ".tsx"].includes(fileExtension)) {
-    // XXX: It seems babylon is getting a TypeScript plugin.
-    // Should that be used instead?
-    formattingOptions.eslint.parser = "typescript-eslint-parser";
-  }
-
   const prettify = createPrettify(formattingOptions.prettier, prettierPath);
 
   if (onlyPrettier) {
     return prettify(text);
+  }
+
+  if ([".ts", ".tsx"].includes(fileExtension)) {
+    // XXX: It seems babylon is getting a TypeScript plugin.
+    // Should that be used instead?
+    formattingOptions.eslint.parser = "typescript-eslint-parser";
   }
 
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath);


### PR DESCRIPTION
If we forward all text with it's filepath, if there is one, prettier will figure out which parser it should use. This will make this package support all future parsers prettier will add, by default.

We only have to check which files to forward to eslint which is something that changes less frequently. For now we forward files with extension defined in eslint config or default to .js/.jsx/.ts/.tsx files.

Let's compare this approach with #144 and see which we should use.