### PR TITLE
feat: infer jsxBracketSameLine from eslint config

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -115,6 +115,22 @@ const getPrettierOptionsFromESLintRulesTests = [
     options: { jsxBracketSameLine: true },
     fallbackPrettierOptions: { jsxBracketSameLine: true }
   },
+  {
+    rules: { "react/jsx-closing-bracket-location": [2, "after-props"] },
+    options: { jsxBracketSameLine: true }
+  },
+  {
+    rules: { "react/jsx-closing-bracket-location": [2, "tag-aligned"] },
+    options: { jsxBracketSameLine: false }
+  },
+  {
+    rules: {
+      "react/jsx-closing-bracket-location": [2, {
+        nonEmpty: "after-props"
+      }]
+    },
+    options: { jsxBracketSameLine: true }
+  },
 
   // If an ESLint rule is disabled fall back to prettier defaults.
   { rules: { "max-len": [0, { code: 120 }] }, options: {} },
@@ -132,7 +148,8 @@ const getPrettierOptionsFromESLintRulesTests = [
   { rules: { indent: ["warn", 2] }, options: { tabWidth: 2 } },
   { rules: { indent: ["warn", 4] }, options: { tabWidth: 4 } },
   { rules: { indent: ["error", "tab"] }, options: { useTabs: true } },
-  { rules: { indent: [2, "tab"] }, options: { useTabs: true } }
+  { rules: { indent: [2, "tab"] }, options: { useTabs: true } },
+  { rules: { "react/jsx-closing-bracket-location": [0] }, options: {} }
 ];
 
 getPrettierOptionsFromESLintRulesTests.forEach(

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,8 @@ const OPTION_GETTERS = {
     ruleValueToPrettierOption: getUseTabs
   },
   jsxBracketSameLine: {
-    ruleValue: () => RULE_NOT_CONFIGURED,
+    ruleValue: rules =>
+      getRuleValue(rules, "react/jsx-closing-bracket-location", "nonEmpty"),
     ruleValueToPrettierOption: getJsxBracketSameLine
   }
 };
@@ -269,8 +270,20 @@ function getUseTabs(eslintValue, fallbacks) {
 }
 
 function getJsxBracketSameLine(eslintValue, fallbacks) {
-  // TODO: add support for setting jsxBracketSameLine based on eslint config
-  return makePrettierOption("jsxBracketSameLine", eslintValue, fallbacks);
+  let prettierValue;
+
+  if (eslintValue === "after-props") {
+    prettierValue = true;
+  } else if (
+    eslintValue === "tag-aligned" ||
+    eslintValue === "line-aligned" ||
+    eslintValue === "props-aligned"
+  ) {
+    prettierValue = false;
+  } else {
+    prettierValue = eslintValue;
+  }
+  return makePrettierOption("jsxBracketSameLine", prettierValue, fallbacks);
 }
 
 function extractRuleValue(objPath, name, value) {


### PR DESCRIPTION
I've added support for inferring the prettier jsxBracketSameLine option. Since the prettier option does not apply to self closing tags, I'm checking the "nonEmpty" property of the configuration.

Closes #151 