### PR TITLE
feat(perf): Remove unfixable rules

### DIFF
--- a/src/__mocks__/eslint.js
+++ b/src/__mocks__/eslint.js
@@ -2,7 +2,7 @@
 // search around the file system for stuff
 
 const eslint = require.requireActual("eslint");
-const { CLIEngine } = eslint;
+const { CLIEngine, Linter } = eslint;
 
 const mockGetConfigForFileSpy = jest.fn(mockGetConfigForFile);
 mockGetConfigForFileSpy.overrides = {};
@@ -10,6 +10,7 @@ const mockExecuteOnTextSpy = jest.fn(mockExecuteOnText);
 
 module.exports = Object.assign(eslint, {
   CLIEngine: jest.fn(MockCLIEngine),
+  Linter: jest.fn(MockLinter),
   mock: {
     getConfigForFile: mockGetConfigForFileSpy,
     executeOnText: mockExecuteOnTextSpy
@@ -78,3 +79,10 @@ function mockExecuteOnText(...args) {
   }
   return this._originalExecuteOnText(...args);
 }
+
+function MockLinter(...args) {
+  const linter = new Linter(...args);
+  return linter;
+}
+
+MockLinter.prototype = Object.create(Linter.prototype);

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -361,6 +361,16 @@ test("logs if there is a problem making the CLIEngine", () => {
   expect(logger.error).toHaveBeenCalledTimes(1);
 });
 
+test("logs if there is a problem making the Linter", () => {
+  const error = new Error("fake error");
+  eslintMock.Linter.mockImplementation(() => {
+    throw error;
+  });
+  expect(() => format({ text: "" })).toThrowError(error);
+  eslintMock.Linter.mockReset();
+  expect(logger.error).toHaveBeenCalledTimes(1);
+});
+
 function getESLintConfigWithDefaultRules(overrides) {
   return {
     parserOptions: { ecmaVersion: 7 },

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { oneLine, stripIndent } from "common-tags";
 import indentString from "indent-string";
 import getLogger from "loglevel-colored-level-prefix";
 import merge from "lodash.merge";
-import { getOptionsForFormatting } from "./utils";
+import { getOptionsForFormatting, requireModule } from "./utils";
 
 const logger = getLogger({ prefix: "prettier-eslint" });
 
@@ -233,21 +233,6 @@ function getESLintConfig(filePath) {
 function getPrettierConfig(filePath) {
   const prettier = requireModule("prettier", "prettier");
   return prettier.resolveConfig.sync(filePath);
-}
-
-function requireModule(modulePath, name) {
-  try {
-    logger.trace(`requiring "${name}" module at "${modulePath}"`);
-    return require(modulePath);
-  } catch (error) {
-    logger.error(
-      oneLine`
-      There was trouble getting "${name}".
-      Is "${modulePath}" a correct path to the "${name}" module?
-    `
-    );
-    throw error;
-  }
 }
 
 function getModulePath(filePath = __filename, moduleName) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 /* eslint import/no-dynamic-require:0 */
 import { oneLine } from "common-tags";
 import delve from "dlv";
-import { Linter } from "eslint";
 import getLogger from "loglevel-colored-level-prefix";
 
 const logger = getLogger({ prefix: "prettier-eslint" });
@@ -110,7 +109,7 @@ function getRelevantESLintConfig(eslintConfig) {
 }
 
 function getFixableRules(eslintConfig) {
-  const linter = new Linter(eslintConfig);
+  const linter = getESLintLinter("eslint", eslintConfig);
   const rules = linter.getRules();
   const fixableRules = [];
   for (const [name, rule] of rules) {
@@ -413,6 +412,16 @@ function requireModule(modulePath, name) {
       Is "${modulePath}" a correct path to the "${name}" module?
     `
     );
+    throw error;
+  }
+}
+
+function getESLintLinter(eslintPath, eslintOptions) {
+  const { Linter } = requireModule(eslintPath, "eslint");
+  try {
+    return new Linter(eslintOptions);
+  } catch (error) {
+    logger.error(`There was trouble creating the ESLint Linter.`);
     throw error;
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+/* eslint import/no-dynamic-require:0 */
 import { oneLine } from "common-tags";
 import delve from "dlv";
 import { Linter } from "eslint";
@@ -57,7 +58,7 @@ const OPTION_GETTERS = {
 };
 
 /* eslint import/prefer-default-export:0 */
-export { getOptionsForFormatting };
+export { getOptionsForFormatting, requireModule };
 
 function getOptionsForFormatting(
   eslintConfig,
@@ -399,4 +400,19 @@ function makePrettierOption(prettierRuleName, prettierRuleValue, fallbacks) {
     `
   );
   return undefined;
+}
+
+function requireModule(modulePath, name) {
+  try {
+    logger.trace(`requiring "${name}" module at "${modulePath}"`);
+    return require(modulePath);
+  } catch (error) {
+    logger.error(
+      oneLine`
+      There was trouble getting "${name}".
+      Is "${modulePath}" a correct path to the "${name}" module?
+    `
+    );
+    throw error;
+  }
 }


### PR DESCRIPTION
ESLint always lint with all rules you provide, even if you call it with the fix command.
It does this to be able to show you information about the rules it could not fix.
We don't display those messages, so we can remove all unfixable rules and allow ESLint to do less work and in turn run faster.