### PR TITLE
Fix eslint-disable-line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,7 @@ the code has been processed by this module. That is because `prettier` changes
 this:
 
 ```js
-if (x) {
-  // eslint-disable-line
+if (x) { // eslint-disable-line
 }
 ```
 


### PR DESCRIPTION
Seems to have been broken in https://github.com/prettier/prettier-eslint/commit/4cf30e65f0ee6bc2a709ed1d259d75ede9f10908#diff-04c6e90faac2675aa89e2176d2eec7d8L219