### PR TITLE
fix(config): use eslintPath's engine to query for config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ function format(options) {
   const eslintConfig = merge(
     {},
     options.eslintConfig,
-    getESLintConfig(filePath)
+    getESLintConfig(filePath, eslintPath)
   );
 
   if (typeof eslintConfig.globals === "object") {
@@ -213,7 +213,7 @@ function getTextFromFilePath(filePath) {
   }
 }
 
-function getESLintConfig(filePath) {
+function getESLintConfig(filePath, eslintPath) {
   const eslintOptions = {};
   if (filePath) {
     eslintOptions.cwd = path.dirname(filePath);
@@ -224,10 +224,7 @@ function getESLintConfig(filePath) {
       "${filePath || process.cwd()}"
     `
   );
-  const cliEngine = getESLintCLIEngine(
-    require.resolve("eslint"),
-    eslintOptions
-  );
+  const cliEngine = getESLintCLIEngine(eslintPath, eslintOptions);
   try {
     logger.debug(`getting eslint config for file at "${filePath}"`);
     const config = cliEngine.getConfigForFile(filePath);


### PR DESCRIPTION
This fixes an issue when reading a config file in case prettier-eslint and eslint are not in the same *context*.

It can't resolve other eslint modules (plugin / config / parser) defined in the config file

This has been found in prettier/prettier-vscode#332 when updating to v8.7.5

I've tested this patch in prettier/prettier-vscode#335 (I don't know how to test it here)