### PR TITLE
fix: Make eslint --fix work on .mjs files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,8 @@ function format(options) {
     ".js",
     ".jsx",
     ".ts",
-    ".tsx"
+    ".tsx",
+    ".mjs"
   ];
   const fileExtension = path.extname(filePath || "");
 


### PR DESCRIPTION
`.mjs` should be considered JavaScript source code :)