### PR TITLE
[FIX] Don't overwrite parser if provided by user

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@typescript-eslint/parser": "1.10.2",
+    "@typescript-eslint/parser": "^1.10.2",
     "babel-runtime": "^6.26.0",
     "common-tags": "^1.4.0",
     "dlv": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@typescript-eslint/parser": "1.10.2",
     "babel-runtime": "^6.26.0",
     "common-tags": "^1.4.0",
     "dlv": "^1.1.0",
@@ -29,7 +30,6 @@
     "pretty-format": "^23.0.1",
     "require-relative": "^0.8.7",
     "typescript": "^2.5.1",
-    "typescript-eslint-parser": "^16.0.0",
     "vue-eslint-parser": "^2.0.2"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,8 @@ function format(options) {
   }
 
   if ([".vue"].includes(fileExtension)) {
-    formattingOptions.eslint.parser = require.resolve("vue-eslint-parser");
+    formattingOptions.eslint.parser =
+      formattingOptions.eslint.parser || require.resolve("vue-eslint-parser");
   }
 
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath);

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ function format(options) {
   if ([".ts", ".tsx"].includes(fileExtension)) {
     // XXX: It seems babylon is getting a TypeScript plugin.
     // Should that be used instead?
-    formattingOptions.eslint.parser = require.resolve(
+    formattingOptions.eslint.parser = formattingOptions.eslint.parser || require.resolve(
       "typescript-eslint-parser"
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -120,11 +120,9 @@ function format(options) {
   }
 
   if ([".ts", ".tsx"].includes(fileExtension)) {
-    // XXX: It seems babylon is getting a TypeScript plugin.
-    // Should that be used instead?
-    formattingOptions.eslint.parser = formattingOptions.eslint.parser || require.resolve(
-      "typescript-eslint-parser"
-    );
+    formattingOptions.eslint.parser =
+      formattingOptions.eslint.parser ||
+      require.resolve("@typescript-eslint/parser");
   }
 
   if ([".vue"].includes(fileExtension)) {


### PR DESCRIPTION
Bug Repro Gist: https://gist.github.com/bradzacher/07d98abce83ed5a4094ccbfacca8b82f

prettier-eslint overrides the user provided parser with its own parser if it detects it's running on a typescript file.

This was generally okay, because there was very little difference between the parser versions (though there may have been subtle bugs that users didn't notice).

However, I was testing a config with the current `1.1.0` of `@typescript-eslint/eslint-plugin`, and noticed that it wasn't fixing an error I know has a fixer. When I ran `eslint --fix` manually, it worked fine.

After a lot of digging, I finally setup the repro case and noticed that the config passed into eslint included prettier-eslint's local parser (`typescript-eslint-parser`), instead of my configured parser (`@typescript-eslint/parser`).

This change fixes this by allowing the user specified parser to be used.