### PR TITLE
fix: failed CI due to prettier upgrade

### DIFF
--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -2,7 +2,7 @@ const fs = require.requireActual("fs");
 module.exports = Object.assign({}, fs, {
   readFileSync: jest.fn(filename => {
     if (/package\.json$/.test(filename)) {
-      return '{"name": "fake", "version": "0.0.0"}';
+      return '{"name": "fake", "version": "0.0.0", "prettier": {}}';
     } else if (/\.(j|t)s$/.test(filename)) {
       return "var fake = true";
     }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -181,11 +181,11 @@ const tests = [
         }
       },
       text:
-        '<template>\n</template>\n<script>\nfunction foo() { return "foo" }\n</script>\n<style>\n</style>',
+        '<template>\n  <div></div>\n</template>\n<script>\nfunction foo() { return "foo" }\n</script>\n<style>\n</style>',
       filePath: path.resolve("./test.vue")
     },
     output:
-      '<template>\n</template>\n<script>\nfunction foo () {\n  return "foo";\n}\n</script>\n<style>\n</style>'
+      '<template>\n  <div></div>\n</template>\n<script>\nfunction foo () {\n  return "foo";\n}\n</script>\n<style></style>'
   },
   {
     title: "GraphQL example",


### PR DESCRIPTION
Closed #202.

Changes,

- The key one is adding `prettier` field in the mocked `package.json`, which prevents `cosmiconfig`, a hidden dependency of `prettier`, from searching other candidate files. Because [cosmiconfig@5](https://github.com/davidtheclark/cosmiconfig/blob/master/CHANGELOG.md#501) switched from `require-from-string` to `require`. If trying to require a nonexistent file, it will throw an error like `Cannot find module .prettierrc.js`.
- I also updated the Vue example input&output, because `prettier` has changed its behaviour since our last successful build (prettier@1.13.5 and now is 1.18.2). Empty template tag is easy to trigger edge cases and not very common, so a div was added.

Some concerns during fixing (if needed I can open an issue),

- "resolves to the local eslint module" was not a solid test case once there has a global eslint module installed.
- "reads text from fs if filePath is provided but not text" was tricky because it depends on the resolve cache of the previous test case. If running it separately, the expected called times should be 3.

@meyer Sorry for stealing your idea, #209, and sending another PR. It blocks the refactoring of my project and I feel a little urgent.
