### PR TITLE
Move typescript to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "prettier-eslint-cli": "^4.2.1",
     "rimraf": "^2.5.4",
     "semantic-release": "^15.13.16",
-    "strip-indent": "^3.0.0",
-    "typescript": "^3.2.1"
+    "strip-indent": "^3.0.0"
+  },
+  "peerDependencies": {
+    "typescript": "^3.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "prettier": "^1.7.0",
     "pretty-format": "^23.0.1",
     "require-relative": "^0.8.7",
-    "typescript": "^3.2.1",
     "vue-eslint-parser": "^2.0.2"
   },
   "devDependencies": {
@@ -51,7 +50,8 @@
     "prettier-eslint-cli": "^4.2.1",
     "rimraf": "^2.5.4",
     "semantic-release": "^15.13.16",
-    "strip-indent": "^3.0.0"
+    "strip-indent": "^3.0.0",
+    "typescript": "^3.2.1"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Move typescript to the devDependencies because otherwise it is installed when you install this package from npm, and usually this creates problems with the other typescript versions installed.