### PR TITLE
feat(Eslint): Update to Eslint 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "common-tags": "^1.4.0",
     "core-js": "^3.1.4",
     "dlv": "^1.1.0",
-    "eslint": "^5.0.0",
+    "eslint": "^6.5.1",
     "indent-string": "^4.0.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -353,8 +353,10 @@ test('reads text from fs if filePath is provided but not text', () => {
   format({ filePath });
   // format({filePath}).catch(() => {})
   // one hit to get the file and one for the eslintignore
-  expect(fsMock.readFileSync).toHaveBeenCalledTimes(2);
+  expect(fsMock.readFileSync).toHaveBeenCalledTimes(3);
   expect(fsMock.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
+  const eslintIgnoreCall  = fsMock.readFileSync.mock.calls[1][0];
+  expect(eslintIgnoreCall.includes('.eslintignore')).toBeTruthy();
 });
 
 test('logs error if it cannot read the file from the filePath', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,7 +75,7 @@ function getOptionsForFormatting(
 }
 
 function getRelevantESLintConfig(eslintConfig, eslintPath) {
-  const cliEngine = getESLintCLIEngine(eslintPath);
+  const cliEngine = getESLintCLIEngine(eslintPath, { ignore: false });
   // TODO: Actually test this branch
   // istanbul ignore next
   const loadedRules =


### PR DESCRIPTION
Update to Eslint 6
Apparently any call to CLIEngine(eslintOptions) where eslintOptions doesn't contain a cwd nor a ignore set to false, will lead to reading the eslintignore twice now.
You can try the branch with: 
``` $ yarn add prettier-eslint@hamzahamidi/prettier-eslint#bundles ```
Or 
``` $ npm install --save prettier-eslint@hamzahamidi/prettier-eslint#bundles ```
