### PR TITLE
`;` is present in original text

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install --save-dev prettier-eslint
 ```javascript
 const format = require("prettier-eslint");
 
-// notice, no semicolon in the original text
+// notice, semicolon in the original text
 const sourceCode = "const {foo} = bar";
 
 const options = {


### PR DESCRIPTION
the text before formatting has `;` but the comment said `no semicolon in original text`. Have removed the false `no`