### PR TITLE
Upgrade to Prettier 2

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -277,7 +277,6 @@
       "avatar_url": "https://www.gravatar.com/avatar/e06e0997e8ef2540568c991f3cc0dd03",
       "profile": "http://codehouse.dev",
       "contributions": [
-        "code",
         "maintenance"
       ]
     }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -270,6 +270,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "idahogurl",
+      "name": "Rebecca Vest",
+      "avatar_url": "https://www.gravatar.com/avatar/e06e0997e8ef2540568c991f3cc0dd03",
+      "profile": "http://codehouse.dev",
+      "contributions": [
+        "code",
+        "maintenance"
+      ]
+    }
     }
   ],
   "repoType": "github",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -280,7 +280,6 @@
         "maintenance"
       ]
     }
-    }
   ],
   "repoType": "github",
   "commitConvention": "none"

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -277,7 +277,7 @@
       "avatar_url": "https://www.gravatar.com/avatar/e06e0997e8ef2540568c991f3cc0dd03",
       "profile": "http://codehouse.dev",
       "contributions": [
-        "maintenance"
+        "maintain"
       ]
     }
   ],

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -277,7 +277,10 @@
       "avatar_url": "https://www.gravatar.com/avatar/e06e0997e8ef2540568c991f3cc0dd03",
       "profile": "http://codehouse.dev",
       "contributions": [
-        "maintain"
+        "code",
+        "doc",
+        "maintain",
+        "test"
       ]
     }
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,8 +14,13 @@ const config = {
     ],
     "comma-dangle": ["error", "never"],
     "arrow-parens": ["error", "as-needed"],
-    "array-element-newline": ["error", "never"],
-    "array-bracket-newline": ["error", "never"]
+    "array-element-newline": ["error", "consistent"],
+    "array-bracket-newline": [
+      "error",
+      {
+        multiline: true
+      }
+    ]
   }
 };
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,19 +9,12 @@ const config = {
       {
         anonymous: "never",
         named: "never",
-        asyncArrow: "always"
-      }
+        asyncArrow: "always",
+      },
     ],
     "comma-dangle": ["error", "never"],
     "arrow-parens": ["error", "as-needed"],
-    "array-element-newline": ["error", "consistent"],
-    "array-bracket-newline": [
-      "error",
-      {
-        multiline: true
-      }
-    ]
-  }
+  },
 };
 
 module.exports = config;

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 const config = {
   extends: ["kentcdodds", "kentcdodds/jest"],
+  parser: "babel-eslint",
   rules: {
     "valid-jsdoc": "off",
     "max-len": "off",
@@ -10,7 +11,11 @@ const config = {
         named: "never",
         asyncArrow: "always"
       }
-    ]
+    ],
+    "comma-dangle": ["error", "never"],
+    "arrow-parens": ["error", "as-needed"],
+    "array-element-newline": ["error", "never"],
+    "array-bracket-newline": ["error", "never"]
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This formats your code via `prettier`, and then passes the result of that to
 formatting capabilities, but also benefit from the configuration capabilities of
 `eslint`.
 
-> For files with an extension of `.css`, `.less`, `.scss`, or `.json` this only
+> For files with an extension of `.css`, `.gql`, `.html`, `.less`, `.md`, `.scss`, or `.json` this only
 > runs `prettier` since `eslint` cannot process those.
 
 ## Installation
@@ -102,16 +102,18 @@ The options to pass for formatting with `prettier`. If not provided,
 of the options and have the remaining options derived via your eslint config.
 This is useful for options like `parser`.
 
-**NOTE:** these options _override_ the eslint config. If you want fallback
-options to be used only in the case that the rule cannot be inferred from
+**NOTE:** These options _override_ the eslint config. If you want fallback
+options to be used only in the case that the option cannot be inferred from
 eslint, see "fallbackPrettierOptions" below.
+
+**NOTE:** The option `parser` is derived from the `eslintConfig`, `fallbackPrettierOptions`, or `filePath` extension when it's not provided. If the attempt is unsuccessful, `parser` defaults to `babel` as its value, which may cause unexpected formatting results.
 
 #### fallbackPrettierOptions (?Object)
 
 The options to pass for formatting with `prettier` if `prettier-eslint` is not
 able to create the options based on the the `eslintConfig` (whether that's
 provided or derived via `filePath`). These options will only be used in the case
-that the corresponding eslint rule cannot be found and the prettier option has
+that the corresponding eslint config setting cannot be found and the prettier option has
 not been manually defined in `prettierOptions`. If the fallback is not given,
 `prettier-eslint` will just use the default `prettier` value in this scenario.
 
@@ -181,9 +183,9 @@ fall back to the `prettier` defaults:
   bracketSpacing: true,
   semi: true,
   useTabs: false,
+  parser: 'babel',
   // prettier-eslint doesn't currently support
-  // inferring these two (Pull Requests welcome):
-  parser: 'babylon',
+  // inferring this (Pull Request welcome):
   jsxBracketSameLine: false,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This is useful for options like `parser`.
 options to be used only in the case that the option cannot be inferred from
 eslint, see "fallbackPrettierOptions" below.
 
-**NOTE:** The option `parser` is derived from the `eslintConfig`, `fallbackPrettierOptions`, or `filePath` extension when it's not provided. If the attempt is unsuccessful, `parser` defaults to `babel` as its value, which may cause unexpected formatting results.
+**NOTE:** The option `parser` is derived from the `eslintConfig`, `fallbackPrettierOptions`, or `filePath` when it's not provided. If the attempt is unsuccessful, `parser` defaults to `babel` as its value, which may cause unexpected formatting results.
 
 #### fallbackPrettierOptions (?Object)
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "indent-string": "^4.0.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "prettier": "^1.7.0",
+    "prettier": "^2.0.5",
     "pretty-format": "^23.0.1",
     "require-relative": "^0.8.7",
     "typescript": "^3.2.1",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -149,6 +149,22 @@ const tests = [
     output: '.stop {\n  color: red;\n}'
   },
   {
+    title: 'HTML example',
+    input: {
+      text: `<div class="stop">\n\tRed</div>`,
+      filePath: path.resolve('./test.html')
+    },
+    output: '<div class="stop">\n  Red\n</div>'
+  },
+  {
+    title: 'Markdown example',
+    input: {
+      text: '1. John\n3. George\n2. Paul\n4. Ringo',
+      filePath: path.resolve('./test.md')
+    },
+    output: '1. John\n2. George\n3. Paul\n4. Ringo'
+  },
+  {
     title: 'LESS example',
     input: {
       text: '.stop{color:red};',
@@ -247,6 +263,7 @@ tests.forEach(({ title, modifier, input, output }) => {
     // adding the newline in the expected because
     // prettier adds a newline to the end of the input
     expect(actual).toBe(`${expected}\n`);
+    if (!input.filePath) expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -313,3 +313,140 @@ test('Turn off unfixable rules', () => {
     useEslintrc: false
   });
 });
+
+const emptyESLintConfig = { rules: [] };
+
+const getPrettierParserTests = [
+  {
+    eslintConfig: { rules: [], parser: 'babel-eslint' },
+    parser: 'babel'
+  },
+  {
+    eslintConfig: { rules: [], parser: '@typescript-eslint' },
+    parser: 'typescript'
+  },
+  {
+    eslintConfig: { rules: [], parser: 'vue-eslint-parser' },
+    parser: 'vue'
+  },
+  {
+    eslintConfig: { rules: [], parser: 'unknown-parser' },
+    parser: 'babel'
+  },
+  {
+    eslintConfig: { rules: [], parser: 'unknown-parser' },
+    fallbackPrettierOptions: { parser: 'typescript' },
+    parser: 'typescript'
+  },
+  {
+    eslintConfig: { rules: [], parser: 'babel-eslint' },
+    fallbackPrettierOptions: { parser: 'ignored' },
+    parser: 'babel'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.css',
+    parser: 'css'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.gql',
+    parser: 'graphql'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.html',
+    parser: 'html'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.md',
+    parser: 'markdown'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.js',
+    parser: 'babel'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.json',
+    parser: 'json'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.jsx',
+    parser: 'babel'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.less',
+    parser: 'less'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.scss',
+    parser: 'scss'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.tsx',
+    parser: 'typescript'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.ts',
+    parser: 'typescript'
+  }
+];
+
+getPrettierParserTests.forEach(
+  (
+    { eslintConfig, fallbackPrettierOptions = {}, fileExtension, parser },
+    index
+  ) => {
+    test(`getPrettierParserTests ${index}`, () => {
+      const { prettier } = getOptionsForFormatting(
+        eslintConfig,
+        {},
+        fallbackPrettierOptions,
+        eslintPath,
+        fileExtension
+      );
+      expect(prettier.parser).toEqual(parser);
+    });
+  }
+);
+
+const getESLintParserTests = [
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.ts',
+    parser: '@typescript-eslint'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.tsx',
+    parser: '@typescript-eslint'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
+    fileExtension: '.vue',
+    parser: 'vue-eslint-parser'
+  }
+];
+
+getESLintParserTests.forEach(
+  ({ eslintConfig, fileExtension, parser }, index) => {
+    test(`getESLintParserTests ${index}`, () => {
+      const { eslint } = getOptionsForFormatting(
+        eslintConfig,
+        {},
+        {},
+        eslintPath,
+        fileExtension
+      );
+      expect(eslint.parser).toContain(parser);
+    });
+  }
+);

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -343,80 +343,16 @@ const getPrettierParserTests = [
     fallbackPrettierOptions: { parser: 'ignored' },
     parser: 'babel'
   }
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   filePath: path.resolve('./mock/default-config.js'),
-  //   parser: 'css'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.gql',
-  //   parser: 'graphql'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.html',
-  //   parser: 'html'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.md',
-  //   parser: 'markdown'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.mjs',
-  //   parser: 'babel'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.js',
-  //   parser: 'babel'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.json',
-  //   parser: 'json'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.jsx',
-  //   parser: 'babel'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.less',
-  //   parser: 'less'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.scss',
-  //   parser: 'scss'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.tsx',
-  //   parser: 'typescript'
-  // },
-  // {
-  //   eslintConfig: emptyESLintConfig,
-  //   fileExtension: '.ts',
-  //   parser: 'typescript'
-  // }
 ];
 
 getPrettierParserTests.forEach(
-  (
-    { eslintConfig, fallbackPrettierOptions = {}, fileExtension, parser },
-    index
-  ) => {
+  ({ eslintConfig, fallbackPrettierOptions = {}, parser }, index) => {
     test(`getPrettierParserTests ${index}`, () => {
       const { prettier } = getOptionsForFormatting(
         eslintConfig,
         {},
         fallbackPrettierOptions,
-        eslintPath,
-        fileExtension
+        eslintPath
       );
       expect(prettier.parser).toEqual(parser);
     });

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -342,67 +342,67 @@ const getPrettierParserTests = [
     eslintConfig: { rules: [], parser: 'babel-eslint' },
     fallbackPrettierOptions: { parser: 'ignored' },
     parser: 'babel'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.css',
-    parser: 'css'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.gql',
-    parser: 'graphql'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.html',
-    parser: 'html'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.md',
-    parser: 'markdown'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.mjs',
-    parser: 'babel'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.js',
-    parser: 'babel'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.json',
-    parser: 'json'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.jsx',
-    parser: 'babel'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.less',
-    parser: 'less'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.scss',
-    parser: 'scss'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.tsx',
-    parser: 'typescript'
-  },
-  {
-    eslintConfig: emptyESLintConfig,
-    fileExtension: '.ts',
-    parser: 'typescript'
   }
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   filePath: path.resolve('./mock/default-config.js'),
+  //   parser: 'css'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.gql',
+  //   parser: 'graphql'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.html',
+  //   parser: 'html'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.md',
+  //   parser: 'markdown'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.mjs',
+  //   parser: 'babel'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.js',
+  //   parser: 'babel'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.json',
+  //   parser: 'json'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.jsx',
+  //   parser: 'babel'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.less',
+  //   parser: 'less'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.scss',
+  //   parser: 'scss'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.tsx',
+  //   parser: 'typescript'
+  // },
+  // {
+  //   eslintConfig: emptyESLintConfig,
+  //   fileExtension: '.ts',
+  //   parser: 'typescript'
+  // }
 ];
 
 getPrettierParserTests.forEach(

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -365,6 +365,11 @@ const getPrettierParserTests = [
   },
   {
     eslintConfig: emptyESLintConfig,
+    fileExtension: '.mjs',
+    parser: 'babel'
+  },
+  {
+    eslintConfig: emptyESLintConfig,
     fileExtension: '.js',
     parser: 'babel'
   },

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,14 @@ function format(options) {
     })
   );
 
-  const eslintExtensions = eslintConfig.extensions || ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.vue'];
+  const eslintExtensions = eslintConfig.extensions || [
+    '.js',
+    '.jsx',
+    '.ts',
+    '.tsx',
+    '.mjs',
+    '.vue'
+  ];
 
   // If we don't get filePath run eslint on text, otherwise only run eslint
   // if it's a configured extension or fall back to a "supported" file type.

--- a/src/index.js
+++ b/src/index.js
@@ -246,12 +246,16 @@ function getESLintConfig(filePath, eslintPath) {
 
 function getPrettierConfig(filePath, prettierPath) {
   const prettier = requireModule(prettierPath, 'prettier');
-  return (
+  const config =
     (prettier.resolveConfig &&
       prettier.resolveConfig.sync &&
       prettier.resolveConfig.sync(filePath)) ||
-    {}
-  );
+    {};
+  if (filePath && !config.parser) {
+    const fileInfo = prettier.getFileInfo.sync(filePath);
+    config.parser = fileInfo.inferredParser;
+  }
+  return config;
 }
 
 function getModulePath(filePath = __filename, moduleName) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
 /* eslint complexity: [1, 13] */
+// need trimStart and trimEnd for Node 8
+import 'core-js/modules/es.string.trim-start';
+import 'core-js/modules/es.string.trim-end';
 import fs from 'fs';
 import path from 'path';
 import requireRelative from 'require-relative';
@@ -76,11 +79,13 @@ function format(options) {
     options.prettierOptions
   );
 
+  const fileExtension = path.extname(filePath || '');
   const formattingOptions = getOptionsForFormatting(
     eslintConfig,
     prettierOptions,
     fallbackPrettierOptions,
-    eslintPath
+    eslintPath,
+    fileExtension
   );
 
   logger.debug(
@@ -97,15 +102,7 @@ function format(options) {
     })
   );
 
-  const eslintExtensions = eslintConfig.extensions || [
-    '.js',
-    '.jsx',
-    '.ts',
-    '.tsx',
-    '.mjs',
-    '.vue'
-  ];
-  const fileExtension = path.extname(filePath || '');
+  const eslintExtensions = eslintConfig.extensions || ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.vue'];
 
   // If we don't get filePath run eslint on text, otherwise only run eslint
   // if it's a configured extension or fall back to a "supported" file type.
@@ -117,17 +114,6 @@ function format(options) {
 
   if (onlyPrettier) {
     return prettify(text);
-  }
-
-  if (['.ts', '.tsx'].includes(fileExtension)) {
-    formattingOptions.eslint.parser =
-      formattingOptions.eslint.parser ||
-      require.resolve('@typescript-eslint/parser');
-  }
-
-  if (['.vue'].includes(fileExtension)) {
-    formattingOptions.eslint.parser =
-      formattingOptions.eslint.parser || require.resolve('vue-eslint-parser');
   }
 
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath);

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,20 +55,6 @@ const OPTION_GETTERS = {
     ruleValueToPrettierOption: getArrowParens
   }
 };
-const PARSER_EXTENSION_MAPPING = {
-  css: 'css',
-  gql: 'graphql',
-  html: 'html',
-  js: 'babel',
-  json: 'json',
-  jsx: 'babel',
-  less: 'less',
-  md: 'markdown',
-  mjs: 'babel',
-  scss: 'scss',
-  tsx: 'typescript',
-  ts: 'typescript'
-};
 /* eslint import/prefer-default-export:0 */
 export { getESLintCLIEngine, getOptionsForFormatting, requireModule };
 
@@ -79,11 +65,11 @@ function getOptionsForFormatting(
   eslintPath,
   fileExtension
 ) {
-  const eslint = getRelevantESLintConfig({
+  const eslint = getRelevantESLintConfig(
     eslintConfig,
     eslintPath,
     fileExtension
-  });
+  );
 
   const prettier = getPrettierOptionsFromESLintRules(
     eslintConfig,
@@ -92,9 +78,8 @@ function getOptionsForFormatting(
   );
   prettier.parser = getPrettierOptionsParser(
     prettierOptions.parser,
-    fallbackPrettierOptions.parser,
     eslint.parser,
-    fileExtension
+    fallbackPrettierOptions.parser
   );
 
   return { eslint, prettier };
@@ -115,7 +100,7 @@ function getESLintConfigParser(parser, fileExtension) {
   return undefined;
 }
 
-function getRelevantESLintConfig({ eslintConfig, eslintPath, fileExtension }) {
+function getRelevantESLintConfig(eslintConfig, eslintPath, fileExtension) {
   const cliEngine = getESLintCLIEngine(eslintPath);
   // TODO: Actually test this branch
   // istanbul ignore next
@@ -451,25 +436,20 @@ function makePrettierOption(prettierRuleName, prettierRuleValue, fallbacks) {
 
 function getPrettierOptionsParser(
   prettierParser,
-  fallbackPrettierParser,
   eslintParser,
-  fileExtension
+  fallbackPrettierParser
 ) {
   const parser =
     prettierParser ||
     getPrettierParserFromESLintConfig(eslintParser) ||
     fallbackPrettierParser;
-
-  const mappedParser =
-    fileExtension && PARSER_EXTENSION_MAPPING[fileExtension.slice(1)];
-
-  if (!parser && !mappedParser) {
+  if (!parser) {
     logger.warn(
       `The prettier option 'parser' cannot be inferred, using 'babel' as fallback.`
     );
     return 'babel';
   }
-  return parser || mappedParser;
+  return parser;
 }
 
 function getPrettierParserFromESLintConfig(esLintParser) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,7 @@ const PARSER_EXTENSION_MAPPING = {
   jsx: 'babel',
   less: 'less',
   md: 'markdown',
+  mjs: 'babel',
   scss: 'scss',
   tsx: 'typescript',
   ts: 'typescript'
@@ -121,7 +122,10 @@ function getRelevantESLintConfig({ eslintConfig, eslintPath, fileExtension }) {
   const loadedRules =
     (cliEngine.getRules && cliEngine.getRules()) ||
     // XXX: Fallback list of unfixable rules, when using and old version of eslint
-    new Map([['global-require', { meta: {} }], ['no-with', { meta: {} }]]);
+    new Map([
+      ['global-require', { meta: {} }],
+      ['no-with', { meta: {} }]
+    ]);
 
   const { rules } = eslintConfig;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,6 +55,7 @@ const OPTION_GETTERS = {
     ruleValueToPrettierOption: getArrowParens
   }
 };
+
 /* eslint import/prefer-default-export:0 */
 export { getESLintCLIEngine, getOptionsForFormatting, requireModule };
 
@@ -434,6 +435,22 @@ function makePrettierOption(prettierRuleName, prettierRuleValue, fallbacks) {
   return undefined;
 }
 
+function getPrettierParserFromESLintConfig(eslintParser) {
+  if (eslintParser) {
+    if (eslintParser.includes('babel-eslint')) {
+      return 'babel';
+    }
+    if (eslintParser.includes('@typescript-eslint')) {
+      return 'typescript';
+    }
+    if (eslintParser.includes('vue-eslint-parser')) {
+      return 'vue';
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 function getPrettierOptionsParser(
   prettierParser,
   eslintParser,
@@ -450,22 +467,6 @@ function getPrettierOptionsParser(
     return 'babel';
   }
   return parser;
-}
-
-function getPrettierParserFromESLintConfig(esLintParser) {
-  if (esLintParser) {
-    if (esLintParser.includes('babel-eslint')) {
-      return 'babel';
-    }
-    if (esLintParser.includes('@typescript-eslint')) {
-      return 'typescript';
-    }
-    if (esLintParser.includes('vue-eslint-parser')) {
-      return 'vue';
-    }
-    return undefined;
-  }
-  return undefined;
 }
 
 function requireModule(modulePath, name) {


### PR DESCRIPTION
Prettier 2 causes two major breaking changes.
1) Doesn't work in Node 8
2) It requires `parser` to be defined. Prettier warns `No parser and no filepath given, using 'babel' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.`

**Fixes:**
1) I added an import of `trimStart` and `trimEnd` from the `core-js` package
2)  I attempt to derive the parser using the value in the `esLintConfig`, `fallbackPrettierOptions` or `filePath` file extension if not provided in the `prettierOptions`. I give it`babel` by default if it cannot be derived. 