### PR TITLE
feat: exit on lint error and report errors and warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/parser": "^3.0.0",
     "common-tags": "^1.4.0",
     "dlv": "^1.1.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.2.0",
     "indent-string": "^4.0.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -127,14 +127,16 @@ async function format(options) {
   }
 
   if (['.ts', '.tsx'].includes(fileExtension)) {
-    formattingOptions.eslint.parser =
-      formattingOptions.eslint.parser ||
-      require.resolve('@typescript-eslint/parser');
+    formattingOptions.eslint.parser = require.resolve('@typescript-eslint/parser');
+    for (const k in formattingOptions.eslint.rules) {
+      if (k.includes('vue/')) {
+        formattingOptions.eslint.rules[k] = ['off'];
+      }
+    }
   }
 
   if (['.vue'].includes(fileExtension)) {
-    formattingOptions.eslint.parser =
-      formattingOptions.eslint.parser || require.resolve('vue-eslint-parser');
+    formattingOptions.eslint.parser = require.resolve('vue-eslint-parser');
   }
 
   const eslintFix = createEslintFix(formattingOptions.eslint, eslintPath, options.exitOnLintErr);

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,9 +63,10 @@ function getOptionsForFormatting(
   eslintConfig,
   prettierOptions = {},
   fallbackPrettierOptions = {},
-  eslintPath
+  eslintPath,
+  exitOnLintErr
 ) {
-  const eslint = getRelevantESLintConfig(eslintConfig, eslintPath);
+  const eslint = getRelevantESLintConfig(eslintConfig, eslintPath,exitOnLintErr);
   const prettier = getPrettierOptionsFromESLintRules(
     eslintConfig,
     prettierOptions,
@@ -74,7 +75,7 @@ function getOptionsForFormatting(
   return { eslint, prettier };
 }
 
-function getRelevantESLintConfig(eslintConfig, eslintPath) {
+function getRelevantESLintConfig(eslintConfig, eslintPath, exitOnLintErr) {
   const cliEngine = getESLintCLIEngine(eslintPath);
   // TODO: Actually test this branch
   // istanbul ignore next
@@ -87,7 +88,7 @@ function getRelevantESLintConfig(eslintConfig, eslintPath) {
 
   logger.debug('turning off unfixable rules');
 
-  const relevantRules = Object.entries(rules).reduce(
+  const relevantRules = exitOnLintErr ? rules : Object.entries(rules).reduce(
     (rulesAccumulator, [name, rule]) => {
       if (loadedRules.has(name)) {
         const {


### PR DESCRIPTION
1. feat exit on lint error by options.exitOnLintErr, by default it does not exit when lint error
2. update eslint to 7.2 so we can use getFormatter in cliEngine
3. use es6 export 
4. format become async so that we can use formatter 
