### PR TITLE
add dependency on core-js@^3.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@typescript-eslint/parser": "^3.0.0",
     "common-tags": "^1.4.0",
+    "core-js": "^3.6.5",
     "dlv": "^1.1.0",
     "eslint": "^6.8.0",
     "indent-string": "^4.0.0",


### PR DESCRIPTION
When using `@babel/preset-env` you need to take a dependency on `core-js` because it will inject runtime references in either `entry` or `usage` (in this case we are using `usage`).

https://babeljs.io/docs/en/babel-preset-env#usebuiltins

Fixes #348 