### PR TITLE
Support ESLint 7 (fixes #401)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -292,6 +292,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "cy6erskunk",
+      "name": "Igor",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/754849?v=4",
+      "profile": "https://github.com/cy6erskunk",
+      "contributions": [
+        "maintenance"
+      ]
     }
   ],
   "repoType": "github",

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
   - '10'
   - '12'
+  - '14'
 script:
   - npm start validate
   - npx codecov

--- a/README.md
+++ b/README.md
@@ -302,10 +302,14 @@ Thanks goes to these people ([emoji key][emojis]):
     <td align="center"><a href="https://hamidihamza.com"><img src="https://avatars0.githubusercontent.com/u/22576950?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Hamza Hamidi</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=hamzahamidi" title="Code">💻</a> <a href="#ideas-hamzahamidi" title="Ideas, Planning, & Feedback">🤔</a> <a href="#maintenance-hamzahamidi" title="Maintenance">🚧</a> <a href="#tool-hamzahamidi" title="Tools">🔧</a> <a href="https://github.com/prettier/prettier-eslint/pulls?q=is%3Apr+reviewed-by%3Ahamzahamidi" title="Reviewed Pull Requests">👀</a></td>
     <td align="center"><a href="https://github.com/iamrajiv"><img src="https://avatars0.githubusercontent.com/u/42106787?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rajiv Ranjan Singh</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=iamrajiv" title="Code">💻</a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/cy6erskunk"><img src="https://avatars3.githubusercontent.com/u/754849?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Igor</b></sub></a><br /><a href="#maintenance-cy6erskunk" title="Maintenance">🚧</a></td>
+  </tr>
 </table>
 
-<!-- markdownlint-enable -->
+<!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/parser": "^3.0.0",
     "common-tags": "^1.4.0",
     "dlv": "^1.1.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.9.0",
     "indent-string": "^4.0.0",
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
@@ -53,7 +53,7 @@
     "strip-indent": "^3.0.0"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "all-contributors-cli": "^6.7.0",
     "babel-jest": "^25.0.0",
     "chalk": "^2.1.0",
-    "eslint-config-kentcdodds": "~14.13.0",
+    "eslint-config-kentcdodds": "~16.0.1",
     "husky": "^2.4.1",
     "jest": "^25.0.0",
     "jest-cli": "^25.0.0",


### PR DESCRIPTION
- upgrades eslint to the latest version as suggested in #401 
- updates contributors list as described in the [contributing guidelines](https://github.com/prettier/prettier-eslint/blob/master/CONTRIBUTING.md)