### PR TITLE
feat(prettier): Respect editor config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -301,6 +301,15 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "kvetis",
+      "name": "Martin Večeřa",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/4200436?v=4",
+      "profile": "http://www.kvetis.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Thanks goes to these people ([emoji key][emojis]):
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/cy6erskunk"><img src="https://avatars3.githubusercontent.com/u/754849?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Igor</b></sub></a><br /><a href="#maintenance-cy6erskunk" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="http://www.kvetis.com/"><img src="https://avatars1.githubusercontent.com/u/4200436?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Martin Večeřa</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=kvetis" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -353,7 +353,7 @@ test('reads text from fs if filePath is provided but not text', () => {
 
   const filePath = '/blah-blah/some-file.js';
   format({ filePath });
-  
+
   expect(readFileSyncMockSpy).toHaveBeenCalledWith(filePath, 'utf8');
 
 });
@@ -370,7 +370,7 @@ test('logs error if it cannot read the file from the filePath', () => {
   fsMock.readFileSync = originalMock;
 });
 
-test('calls prettier.resolveConfig.sync with the file path', () => {
+test('calls prettier.resolveConfig.sync with the file path and editorconfig', () => {
   const filePath = require.resolve('../../tests/fixtures/paths/foo.js');
   format({
     filePath,
@@ -378,7 +378,10 @@ test('calls prettier.resolveConfig.sync with the file path', () => {
     eslintConfig: getESLintConfigWithDefaultRules()
   });
   expect(prettierMock.resolveConfig.sync).toHaveBeenCalledTimes(1);
-  expect(prettierMock.resolveConfig.sync).toHaveBeenCalledWith(filePath);
+  expect(prettierMock.resolveConfig.sync).toHaveBeenCalledWith(
+    filePath,
+    { editorconfig: true },
+  );
 });
 
 test('does not raise an error if prettier.resolveConfig.sync is not defined', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,7 @@ function getPrettierConfig(filePath, prettierPath) {
   return (
     (prettier.resolveConfig &&
       prettier.resolveConfig.sync &&
-      prettier.resolveConfig.sync(filePath)) ||
+      prettier.resolveConfig.sync(filePath, { editorconfig: true })) ||
     {}
   );
 }


### PR DESCRIPTION
Prettier has the ability to read `.editorconfig` while resolving the rules. These are read automatically when using the prettier CLI.
If the `.editorconfig` file is not found the option is ignored and does not result in error.

This might introduce breaking change (in the author's case a fix, though) for the folks
who have  `.editorconfig` in their folder structure, but it is not in line with prettier config.
There might be a legitimate reason for that, but I cannot think of any.

I did not feel this needed a new option to pass into prettier-eslint. I consider is more a discussion PR, since I don't know what you people think of the correct approach should be. So I just picked one solution and updated it. Maybe I could add a test that proves that the editorconfig works.