### PR TITLE
feat: cache ESLint instances for faster formatting

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -320,6 +320,15 @@
         "bug",
         "code"
       ]
+    },
+      "login": "taye",
+      "name": "taye",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1679746?v=4",
+      "profile": "https://taye.me",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Thanks goes to these people ([emoji key][emojis]):
     <td align="center"><a href="https://github.com/cy6erskunk"><img src="https://avatars3.githubusercontent.com/u/754849?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Igor</b></sub></a><br /><a href="#maintenance-cy6erskunk" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://campcode.dev/"><img src="https://avatars.githubusercontent.com/u/10620169?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rebecca Vest</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=idahogurl" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/chrisbobbe"><img src="https://avatars.githubusercontent.com/u/22248748?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Bobbe</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/issues?q=author%3Achrisbobbe" title="Bug reports">🐛</a> <a href="https://github.com/prettier/prettier-eslint/commits?author=chrisbobbe" title="Code">💻</a></td>
+    <td align="center"><a href="https://mastodon.social/@taye"><img src="https://avatars.githubusercontent.com/u/1679746?v=4?s=100" width="100px;" alt=""/><br /><sub><b>taye</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=taye" title="Code">💻</a> <a href="https://github.com/prettier/prettier-eslint/commits?author=taye" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/src/__mocks__/other-eslint.js
+++ b/src/__mocks__/other-eslint.js
@@ -1,0 +1,1 @@
+module.exports = require("./eslint");

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { getOptionsForFormatting } from '../utils';
+import { getESLint, getOptionsForFormatting } from '../utils';
 
 const getPrettierOptionsFromESLintRulesTests = [
   {
@@ -312,4 +312,21 @@ test('Turn off unfixable rules', () => {
     globals: {},
     useEslintrc: false
   });
+});
+
+const otherEslintPath = path.join(__dirname, "../__mocks__/other-eslint");
+
+test("Caches eslint cli engine with same path and options", () => {
+  const eslintOptions = {};
+
+  expect(getESLint(eslintPath, eslintOptions)).toBe(getESLint(eslintPath, eslintOptions));
+  expect(getESLint(eslintPath)).toBe(getESLint(eslintPath));
+});
+
+test("Creates new eslint cli engine with different path or options", () => {
+  const eslintOptions = {};
+
+  expect(getESLint(eslintPath, eslintOptions)).not.toBe(getESLint(otherEslintPath, eslintOptions));
+  expect(getESLint(eslintPath)).not.toBe(getESLint(otherEslintPath));
+  expect(getESLint(eslintPath, {})).not.toBe(getESLint(eslintPath, {}));
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -401,12 +401,24 @@ function requireModule(modulePath, name) {
   }
 }
 
+let cachedEslint = {};
 function getESLint(eslintPath, eslintOptions) {
+  if (
+    cachedEslint.eslint &&
+    cachedEslint.eslintPath === eslintPath &&
+    cachedEslint.eslintOptions === eslintOptions
+  ) {
+    return cachedEslint.eslint;
+  }
+
   const { ESLint } = requireModule(eslintPath, 'eslint');
   try {
-    return new ESLint(eslintOptions);
+    const eslint = new ESLint(eslintOptions);
+    cachedEslint = { eslintPath, eslint, eslintOptions };
+
+    return eslint;
   } catch (error) {
-    logger.error('There was trouble creating the ESLint CLIEngine.');
+    logger.error('There was trouble creating the ESLint instance.');
     throw error;
   }
 }


### PR DESCRIPTION
This PR speeds up repeated formatting by reusing the previously created `ESLintCLIEngine` instance when the `eslintPath` and `eslintOptions` that are passed to `getESLintCLIEngine` are identical.

:heart: