### PR TITLE
remove extraneous core-js imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,10 +4,8 @@ const config = {
       '@babel/env',
       {
         targets: {
-          node: '8'
-        },
-        useBuiltIns: 'usage',
-        corejs: 3
+          node: '10'
+        }
       }
     ]
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
 /* eslint complexity: [1, 13] */
 
-// Add node 8 polyfills, to be removed if we decide to let go node 8 support
-import 'core-js/modules/es.string.trim-start'; // eslint-disable-line 
-import 'core-js/modules/es.string.trim-end'; // eslint-disable-line 
-
 import fs from 'fs';
 import path from 'path';
 import requireRelative from 'require-relative';


### PR DESCRIPTION
As the `package.json` already specifies node runtime to be >= 10.x, `core-js` fallback is not necessary. Additionally, it is causing execution error when core-js (at any version!) is not already installed. Replaces also PR #359.