### PR TITLE
ci(GitHub): :green_heart: Use HTTPs for npm publish

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 package-lock=false


### PR DESCRIPTION
BREAKING CHANGE: Only works with ESLint 8. ESLint 8 API changes caused the `format` function to now be asynchronous.