### PR TITLE
fix: :ambulance: Fix invalid ESLint configuration error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -176,15 +176,22 @@ function createEslintFix(eslintConfig, eslintPath) {
       parser: eslintConfig.parser,
       globals: eslintConfig.globals,
       parserOptions: eslintConfig.parserOptions,
-      ignorePatterns: eslintConfig.ignorePattern,
+      ignorePatterns: eslintConfig.ignorePatterns,
+      plugins: eslintConfig.plugins,
+      env: eslintConfig.env,
+      settings: eslintConfig.settings,
+      noInlineConfig: eslintConfig.noInlineConfig,
       ...eslintConfig.overrideConfig
     };
-
     delete eslintConfig.rules;
     delete eslintConfig.parser;
     delete eslintConfig.parserOptions;
     delete eslintConfig.globals;
-    delete eslintConfig.ignorePattern;
+    delete eslintConfig.ignorePatterns;
+    delete eslintConfig.plugins;
+    delete eslintConfig.env;
+    delete eslintConfig.noInlineConfig;
+    delete eslintConfig.settings;
 
     const eslint = getESLint(eslintPath, eslintConfig);
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,7 @@ function createEslintFix(eslintConfig, eslintPath) {
       parser: eslintConfig.parser,
       globals: eslintConfig.globals,
       parserOptions: eslintConfig.parserOptions,
-      ignorePatterns: eslintConfig.ignorePatterns,
+      ignorePatterns: eslintConfig.ignorePatterns || eslintConfig.ignorePattern,
       plugins: eslintConfig.plugins,
       env: eslintConfig.env,
       settings: eslintConfig.settings,
@@ -188,6 +188,7 @@ function createEslintFix(eslintConfig, eslintPath) {
     delete eslintConfig.parserOptions;
     delete eslintConfig.globals;
     delete eslintConfig.ignorePatterns;
+    delete eslintConfig.ignorePattern;
     delete eslintConfig.plugins;
     delete eslintConfig.env;
     delete eslintConfig.noInlineConfig;


### PR DESCRIPTION
While working on `prettier-eslint-cli`, the CLI tests were failing because of an error about invalid ESLint configuration. Come to find out more ESLint configurations exist, namely:
* ignorePatterns
* plugins
* env
* settings
* noInlineConfig