### PR TITLE
chore(prettier): Take Prettier 2.4.0's jsxBracketSameLine → bracketSameLine

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -310,6 +310,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "chrisbobbe",
+      "name": "Chris Bobbe",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22248748?v=4",
+      "profile": "https://github.com/chrisbobbe",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ fall back to the `prettier` defaults:
   // prettier-eslint doesn't currently support
   // inferring these two (Pull Requests welcome):
   parser: 'babylon',
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
 }
 ```
 
@@ -305,12 +305,12 @@ Thanks goes to these people ([emoji key][emojis]):
   <tr>
     <td align="center"><a href="https://github.com/cy6erskunk"><img src="https://avatars3.githubusercontent.com/u/754849?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Igor</b></sub></a><br /><a href="#maintenance-cy6erskunk" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://campcode.dev/"><img src="https://avatars.githubusercontent.com/u/10620169?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rebecca Vest</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/commits?author=idahogurl" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/chrisbobbe"><img src="https://avatars.githubusercontent.com/u/22248748?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Chris Bobbe</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint/issues?q=author%3Achrisbobbe" title="Bug reports">🐛</a> <a href="https://github.com/prettier/prettier-eslint/commits?author=chrisbobbe" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -113,16 +113,16 @@ const getPrettierOptionsFromESLintRulesTests = [
   },
   {
     rules: {},
-    options: { jsxBracketSameLine: true },
-    fallbackPrettierOptions: { jsxBracketSameLine: true }
+    options: { bracketSameLine: true },
+    fallbackPrettierOptions: { bracketSameLine: true }
   },
   {
     rules: { 'react/jsx-closing-bracket-location': [2, 'after-props'] },
-    options: { jsxBracketSameLine: true }
+    options: { bracketSameLine: true }
   },
   {
     rules: { 'react/jsx-closing-bracket-location': [2, 'tag-aligned'] },
-    options: { jsxBracketSameLine: false }
+    options: { bracketSameLine: false }
   },
   {
     rules: {
@@ -133,7 +133,7 @@ const getPrettierOptionsFromESLintRulesTests = [
         }
       ]
     },
-    options: { jsxBracketSameLine: true }
+    options: { bracketSameLine: true }
   },
   {
     rules: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,10 +46,10 @@ const OPTION_GETTERS = {
     ruleValue: rules => getRuleValue(rules, 'indent'),
     ruleValueToPrettierOption: getUseTabs
   },
-  jsxBracketSameLine: {
+  bracketSameLine: {
     ruleValue: rules =>
       getRuleValue(rules, 'react/jsx-closing-bracket-location', 'nonEmpty'),
-    ruleValueToPrettierOption: getJsxBracketSameLine
+    ruleValueToPrettierOption: getBracketSameLine
   },
   arrowParens: {
     ruleValue: rules => getRuleValue(rules, 'arrow-parens'),
@@ -263,7 +263,7 @@ function getUseTabs(eslintValue, fallbacks) {
   return makePrettierOption('useTabs', prettierValue, fallbacks);
 }
 
-function getJsxBracketSameLine(eslintValue, fallbacks) {
+function getBracketSameLine(eslintValue, fallbacks) {
   let prettierValue;
 
   if (eslintValue === 'after-props') {
@@ -278,7 +278,7 @@ function getJsxBracketSameLine(eslintValue, fallbacks) {
     prettierValue = eslintValue;
   }
 
-  return makePrettierOption('jsxBracketSameLine', prettierValue, fallbacks);
+  return makePrettierOption('bracketSameLine', prettierValue, fallbacks);
 }
 
 function getArrowParens(eslintValue, fallbacks) {


### PR DESCRIPTION
prettier/prettier@4992d9720, released in 2.4.0, deprecated the
`jsxBracketSameLine` option in favor of a new, more generic option,
`bracketSameLine`. See docs:
  https://prettier.io/docs/en/options.html#bracket-line

This has caused a warning

>  jsxBracketSameLine is deprecated.

for people using Prettier 2.4.0+, if their ESLint config leads us to
infer and use a value for jsxBracketSameLine.

So, instead of inferring and using a value for jsxBracketSameLine,
do so for the new bracketSameLine.

In d8bf1e3dc, which we released in 14.0.0, we stopped supporting
Prettier versions older than 2.5.1. That means we don't need to
maintain backward-compatible code for users with Prettier <2.4.0,
which doesn't have bracketSameLine.

See discussion:
  https://github.com/prettier/prettier-eslint-cli/pull/430#issuecomment-1124449040