### PR TITLE
Fix the return type of format: string -> Promise<string>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = format;
  * @param {String} options.logLevel - the level for the logs
  *  (error, warn, info, debug, trace)
  * @param {Boolean} options.prettierLast - Run Prettier Last
- * @return {String} - the formatted string
+ * @return {Promise<String>} - the formatted string
  */
 async function format(options) {
   const { logLevel = getDefaultLogLevel() } = options;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,6 @@ declare namespace format {
  * supplied configuration. The auto-formatting is limited to the issues that
  * Prettier and ESLint can automatically fix.
  */
-declare function format(options: format.Options): string;
+declare function format(options: format.Options): Promise<string>;
 
 export = format;


### PR DESCRIPTION
The function declaration was changed in #696 from `function format(options)` to `async function(options)`, the example section in README.md is changed as well, but the doc as well as the later added `types/index.d.ts` from #739 was not updated.