### PR TITLE
Completing the missing LogLevel values 'silent'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare namespace format {
     /**
      * Logging level for the traceback of the synchronous formatting process.
      */
-    type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+    type LogLevel = "error" | "warn" | "info" | "debug" | "trace" | "silent";
 
     /**
      * Options to format text with Prettier and ESLint.


### PR DESCRIPTION
It looks like `logLevel` in README has the value 'silent' and 'slient' does work.