### PR TITLE
chore: upgrade husky to v8

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm start validate

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "scripts": {
+    "prepare": "husky install",
     "start": "nps",
-    "test": "nps test",
-    "precommit": "opt --in pre-commit --exec \"npm start validate\""
+    "test": "nps test"
   },
   "files": [
     "dist",
@@ -45,12 +45,11 @@
     "babel-jest": "^25.0.0",
     "chalk": "^2.1.0",
     "eslint-config-kentcdodds": "^20.0.1",
-    "husky": "^2.4.1",
+    "husky": "^8.0.1",
     "jest": "^25.0.0",
     "jest-cli": "^25.0.0",
     "nps": "^5.7.1",
     "nps-utils": "^1.3.0",
-    "opt-cli": "^1.5.2",
     "prettier-eslint-cli": "^7.0.0",
     "rimraf": "^2.5.4",
     "semantic-release": "^15.13.16",


### PR DESCRIPTION
fixes #746

Getting rid old really old transitive husky@2 dependencies.

Husky v8:
- Zero dependencies and lightweight (6 kB)
- Powered by modern new Git feature (core.hooksPath)
- Follows npm and Yarn best practices regarding autoinstall

`opt-cli` seems to be abandoned (last update 5 years ago).
Looks like this dependency is not needed anymore with the new Husky. (couldn't find other references/usage in the project)