### PR TITLE
update vs-code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ solutions.
   Command Line Interface
 - [`prettier-atom`][atom-plugin] - Atom plugin (check the "ESlint integration"
   checkbox in settings)
-- [`prettier-vscode`][vscode-plugin] - Visual Studio Code plugin (set
-  `prettier.eslintIntegration: true` in settings)
+- [`vs-code-prettier-eslint`][vscode-plugin] - Visual Studio Code plugin
 - [`eslint-plugin-prettier`](https://github.com/not-an-aardvark/eslint-plugin-prettier) -
   ESLint plugin. While prettier-eslint uses `eslint --fix` to change the output of `prettier`, eslint-plugin-prettier keeps the `prettier` output as-is and integrates it with the regular ESLint workflow.
 - [`prettier-eslint-webpack-plugin`](https://github.com/danielterwiel/prettier-eslint-webpack-plugin) -
@@ -355,4 +354,4 @@ MIT
 [all-contributors]: https://github.com/kentcdodds/all-contributors
 [atom-plugin]: https://github.com/prettier/prettier-atom
 [atom-dev-tools]: https://discuss.atom.io/t/how-to-make-developer-tools-appear/16232
-[vscode-plugin]: https://github.com/esbenp/prettier-vscode
+[vscode-plugin]: https://github.com/idahogurl/vs-code-prettier-eslint


### PR DESCRIPTION
for now prettier-vscode removed support of  prettier-eslint

 https://github.com/prettier/prettier-vscode/commit/f6ae3f6268b4a711e425b4caddcf99b435899b15
https://github.com/prettier/prettier-vscode/issues/958