### PR TITLE
chore(deps): Move code from `loglevel-colored-level-prefix` into this…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -320,6 +320,16 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "ashcorr",
+      "name": "Ashleigh Carr",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21217225?v=4",
+      "profile": "https://github.com/ashcorr",
+      "contributions": [
+        "maintenance",
+        "security"
+      ]
     }
   ],
   "repoType": "github",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "eslint": "^8.7.0",
     "indent-string": "^4.0.0",
     "lodash.merge": "^4.6.0",
-    "loglevel-colored-level-prefix": "^1.0.0",
     "prettier": "^2.5.1",
     "pretty-format": "^23.0.1",
     "require-relative": "^0.8.7",
     "typescript": "^4.5.4",
-    "vue-eslint-parser": "^9.1.0"
+    "vue-eslint-parser": "^9.1.0",
+    "loglevel": "^1.4.1",
+    "chalk": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -43,7 +44,6 @@
     "ajv": "^6.12.2",
     "all-contributors-cli": "^6.7.0",
     "babel-jest": "^25.0.0",
-    "chalk": "^2.1.0",
     "eslint-config-kentcdodds": "^20.0.1",
     "husky": "^8.0.1",
     "jest": "^25.0.0",

--- a/src/__mocks__/logger.js
+++ b/src/__mocks__/logger.js
@@ -13,7 +13,7 @@ Object.assign(module.exports, {
   mock
 });
 
-function getLogger() {
+export default function getLogger() {
   return logger;
 }
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -4,10 +4,11 @@ import fsMock from 'fs';
 import stripIndent from 'strip-indent';
 import eslintMock from 'eslint';
 import prettierMock from 'prettier';
-import loglevelMock from 'loglevel-colored-level-prefix';
+import loglevelMock from '../logger';
 import format from '../';
 
 jest.mock('fs');
+jest.mock('../logger');
 
 const {
   mock: { logger }

--- a/src/__tests__/logger.js
+++ b/src/__tests__/logger.js
@@ -1,0 +1,72 @@
+/* eslint no-console:0 */
+import loglevel from 'loglevel';
+import chalk from 'chalk';
+import getLogger from '../logger';
+
+const logMap = {
+  trace: 'trace',
+  debug: 'log',
+  info: 'info',
+  warn: 'warn',
+  error: 'error'
+};
+
+beforeEach(() => {
+  Object.keys(logMap).forEach(logLevel => {
+    console[logMap[logLevel]] = jest.fn();
+  });
+});
+
+Object.keys(logMap).forEach(logLevel => {
+  const logMethod = logMap[logLevel];
+  test(`${logLevel} logs to console.${logMethod}`, () => {
+    const prefix = String(Math.random());
+    const logger = getLogger({ level: 'trace', prefix });
+    const message = `Help me Obi Wan Kenobi. You're my only hope.`;
+    logger[logLevel](message);
+    expect(console[logMethod]).toHaveBeenCalledTimes(1);
+    const logPrefix = expect.stringMatching(
+      new RegExp(`${prefix}.*${logLevel.toUpperCase()}`)
+    );
+    expect(console[logMethod]).toHaveBeenCalledWith(logPrefix, message);
+  });
+});
+
+test('returns the same instance of logger with the same prefix', () => {
+  const prefix = String(Math.random());
+  const logger1 = getLogger({ prefix });
+  const logger2 = getLogger({ prefix });
+  expect(logger2).toBe(logger1);
+});
+
+test('defaults to process.env.LOG_LEVEL if it exists', () => {
+  const originalLogLevel = process.env.LOG_LEVEL;
+  process.env.LOG_LEVEL = 'debug';
+  const logger = getLogger({ prefix: String(Math.random()) });
+  expect(logger.getLevel()).toBe(
+    loglevel.levels[process.env.LOG_LEVEL.toUpperCase()]
+  );
+  process.env.LOG_LEVEL = originalLogLevel;
+});
+
+test('defaults to `warn` if process.env.LOG_LEVEL does not exit', () => {
+  const originalLogLevel = process.env.LOG_LEVEL;
+  delete process.env.LOG_LEVEL;
+  const logger = getLogger({ prefix: String(Math.random()) });
+  expect(logger.getLevel()).toBe(loglevel.levels.WARN);
+  process.env.LOG_LEVEL = originalLogLevel;
+});
+
+test(`defaults the prefix to an empty string`, () => {
+  const message = `hi default!`;
+  const logger = getLogger();
+  logger.warn(message);
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  const {
+    mock: {
+      calls: [[firstCallFirstArg]]
+    }
+  } = console.warn;
+  const prefix = `${chalk.yellow('[WARN]')}:`;
+  expect(firstCallFirstArg).toBe(prefix);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import requireRelative from 'require-relative';
 import prettyFormat from 'pretty-format';
 import { oneLine, stripIndent } from 'common-tags';
 import indentString from 'indent-string';
-import getLogger from 'loglevel-colored-level-prefix';
 import merge from 'lodash.merge';
+import getLogger from './logger';
 import { getESLint, getOptionsForFormatting, requireModule } from './utils';
 
 const logger = getLogger({ prefix: 'prettier-eslint' });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,55 @@
+import loglevel from 'loglevel';
+import chalk from 'chalk';
+
+const loggers = {};
+
+function getLogger({ level = getDefaultLevel(), prefix = '' } = {}) {
+  if (loggers[prefix]) {
+    return loggers[prefix];
+  }
+  const coloredPrefix = prefix ? `${chalk.dim(prefix)} ` : '';
+  const levelPrefix = {
+    TRACE: chalk.dim('[TRACE]'),
+    DEBUG: chalk.cyan('[DEBUG]'),
+    INFO: chalk.blue('[INFO]'),
+    WARN: chalk.yellow('[WARN]'),
+    ERROR: chalk.red('[ERROR]')
+  };
+
+  const logger = loglevel.getLogger(`${prefix}-logger`);
+
+  // this is the plugin "api"
+  const originalFactory = logger.methodFactory;
+  logger.methodFactory = methodFactory;
+
+  const originalSetLevel = logger.setLevel;
+  logger.setLevel = setLevel;
+  logger.setLevel(level);
+  loggers[prefix] = logger;
+  return logger;
+
+  function methodFactory(...factoryArgs) {
+    const { 0: logLevel } = factoryArgs;
+    const rawMethod = originalFactory(...factoryArgs);
+    return (...args) =>
+      rawMethod(
+        `${coloredPrefix}${levelPrefix[logLevel.toUpperCase()]}:`,
+        ...args
+      );
+  }
+
+  function setLevel(levelToSetTo) {
+    const persist = false; // uses browser localStorage
+    return originalSetLevel.call(logger, levelToSetTo, persist);
+  }
+}
+
+function getDefaultLevel() {
+  const { LOG_LEVEL: logLevel } = process.env;
+  if (logLevel === 'undefined' || !logLevel) {
+    return 'warn';
+  }
+  return logLevel;
+}
+
+export default getLogger;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 /* eslint import/no-dynamic-require:0 */
 import { oneLine } from 'common-tags';
 import delve from 'dlv';
-import getLogger from 'loglevel-colored-level-prefix';
 import { Linter } from 'eslint';
+import getLogger from './logger';
 
 const logger = getLogger({ prefix: 'prettier-eslint' });
 const RULE_DISABLED = {};


### PR DESCRIPTION
Moves the code for `loglevel-colored-level-prefix` from https://github.com/kentcdodds/loglevel-colored-level-prefix into this repo.

`loglevel-colored-level-prefix` currently has [vulnerabilities](https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908) due to its reliance on ansi-regex 2.0. I'd prefer to just update `loglevel-colored-level-prefix` but it looks like that repo is archived now. Considering how small a package this is I figured we might just be able to move it into this repo.

I've made some minor alterations to the code of `loglevel-colored-level-prefix` such as changing the imports to use `import` instead of `require`

I believe this package was originally part of this repo so I thought this proverb would be fitting!

> For you are `prettier-eslint`, And to `prettier-eslint` you shall return - Genesis 3:19


Related #643

(alternatively the prettier org could create a fork of loglevel-colored-level-prefix and publish their own version)