### PR TITLE
feat: support handling `.svelte` files

### DIFF
--- a/.changeset/fair-foxes-brake.md
+++ b/.changeset/fair-foxes-brake.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": minor
+---
+
+feat: support handling `.svelte` files

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pretty-format": "^29.7.0",
     "require-relative": "^0.8.7",
     "typescript": "^5.2.2",
-    "vue-eslint-parser": "^9.1.0"
+    "vue-eslint-parser": "^9.1.0",
+    "svelte-eslint-parser": "^0.33.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
     "JounQin (https://www.1stG.me) <admin@1stg.me>"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "prettier-plugin-svelte": "^3.0.0",
+    "svelte-eslint-parser": "*"
+  },
+  "peerDependenciesMeta": {
+    "prettier-plugin-svelte": {
+      "optional": true
+    },
+    "svelte-eslint-parser": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@typescript-eslint/parser": "^6.7.5",
     "common-tags": "^1.4.0",
@@ -54,22 +66,6 @@
     "strip-indent": "^3.0.0",
     "svelte": "^4.2.9",
     "svelte-eslint-parser": "^0.33.1"
-  },
-  "peerDependencies": {
-    "prettier-plugin-svelte": "^3.0.0",
-    "svelte": "^4.2.9",
-    "svelte-eslint-parser": "*"
-  },
-  "peerDependenciesMeta": {
-    "prettier-plugin-svelte": {
-      "optional": true
-    },
-    "svelte": {
-      "optional": true
-    },
-    "svelte-eslint-parser": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=16.10.0"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
     "prettier": "^3.0.1",
+    "prettier-plugin-svelte": "^3.1.2",
     "pretty-format": "^29.7.0",
     "require-relative": "^0.8.7",
+    "svelte": "^4.2.9",
+    "svelte-eslint-parser": "^0.33.1",
     "typescript": "^5.2.2",
-    "vue-eslint-parser": "^9.1.0",
-    "svelte-eslint-parser": "^0.33.1"
+    "vue-eslint-parser": "^9.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.9",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,8 @@
     "lodash.merge": "^4.6.0",
     "loglevel-colored-level-prefix": "^1.0.0",
     "prettier": "^3.0.1",
-    "prettier-plugin-svelte": "^3.1.2",
     "pretty-format": "^29.7.0",
     "require-relative": "^0.8.7",
-    "svelte": "^4.2.9",
-    "svelte-eslint-parser": "^0.33.1",
     "typescript": "^5.2.2",
     "vue-eslint-parser": "^9.1.0"
   },
@@ -54,6 +51,11 @@
     "prettier-eslint-cli": "^8.0.0",
     "rimraf": "^5.0.5",
     "strip-indent": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "prettier-plugin-svelte": "^3.1.2",
+    "svelte": "^4.2.9",
+    "svelte-eslint-parser": "^0.33.1"
   },
   "engines": {
     "node": ">=16.10.0"

--- a/package.json
+++ b/package.json
@@ -49,13 +49,27 @@
     "nps": "^5.7.1",
     "nps-utils": "^1.3.0",
     "prettier-eslint-cli": "^8.0.0",
+    "prettier-plugin-svelte": "^3.1.2",
     "rimraf": "^5.0.5",
-    "strip-indent": "^3.0.0"
+    "strip-indent": "^3.0.0",
+    "svelte": "^4.2.9",
+    "svelte-eslint-parser": "^0.33.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "prettier-plugin-svelte": "^3.1.2",
     "svelte": "^4.2.9",
     "svelte-eslint-parser": "^0.33.1"
+  },
+  "peerDependenciesMeta": {
+    "prettier-plugin-svelte": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    },
+    "svelte-eslint-parser": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=16.10.0"

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "svelte-eslint-parser": "^0.33.1"
   },
   "peerDependencies": {
-    "prettier-plugin-svelte": "^3.1.2",
+    "prettier-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.9",
-    "svelte-eslint-parser": "^0.33.1"
+    "svelte-eslint-parser": "*"
   },
   "peerDependenciesMeta": {
     "prettier-plugin-svelte": {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -196,16 +196,15 @@ const tests = [
   {
     title: 'Svelte example',
     input: {
-      eslintConfig: {
-        rules: {
-          'space-before-function-paren': [2, 'always']
-        }
-      },
+      prettierOptions: {
+          plugins: ['prettier-plugin-svelte'],
+          overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }]
+        },
       text: '<script>\nfunction foo() { return "foo" }\n</script>\n  <div>test</div>\n<style>\n</style>',
       filePath: path.resolve('./test.svelte')
     },
     output:
-      '<script>\nfunction foo () {\n  return "foo";\n}\n</script>\n<div>test</div>\n<style></style>'
+      '<script>\n  function foo() {\n    return "foo";\n  }\n</script>\n\n<div>test</div>\n\n<style>\n</style>'
   },
   {
     title: 'GraphQL example',

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -194,6 +194,20 @@ const tests = [
       '<template>\n  <div></div>\n</template>\n<script>\nfunction foo () {\n  return "foo";\n}\n</script>\n<style></style>'
   },
   {
+    title: 'Svelte example',
+    input: {
+      eslintConfig: {
+        rules: {
+          'space-before-function-paren': [2, 'always']
+        }
+      },
+      text: '<script>\nfunction foo() { return "foo" }\n</script>\n  <div>test</div>\n<style>\n</style>',
+      filePath: path.resolve('./test.svelte')
+    },
+    output:
+      '<script>\nfunction foo () {\n  return "foo";\n}\n</script>\n<div>test</div>\n<style></style>'
+  },
+  {
     title: 'GraphQL example',
     input: {
       text: 'type Query{test: Test}',

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ async function format(options) {
  *  `r.output` is the formatted string and `r.messages` is an array of
  *  message specifications from eslint.
  */
+// eslint-disable-next-line complexity
 async function analyze(options) {
   const { logLevel = getDefaultLogLevel() } = options;
   logger.setLevel(logLevel);

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,8 @@ async function analyze(options) {
     '.ts',
     '.tsx',
     '.mjs',
-    '.vue'
+    '.vue',
+    '.svelte'
   ];
   const fileExtension = path.extname(filePath || '');
 
@@ -136,6 +137,10 @@ async function analyze(options) {
 
   if (['.vue'].includes(fileExtension)) {
     formattingOptions.eslint.parser ||= require.resolve('vue-eslint-parser');
+  }
+
+  if (['.svelte'].includes(fileExtension)) {
+    formattingOptions.eslint.parser ||= require.resolve('svelte-eslint-parser');
   }
 
   const eslintFix = await createEslintFix(formattingOptions.eslint, eslintPath);


### PR DESCRIPTION
Without this addition, prettier-eslint will only run the Prettier step for .svelte files, but NOT the Eslint step!

close #525