### PR TITLE
Support for TypeScript 5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^6.7.5",
+    "@typescript-eslint/parser": "^7.14.1",
     "common-tags": "^1.4.0",
     "dlv": "^1.1.0",
     "eslint": "^8.7.0",


### PR DESCRIPTION
Fixes #1015

Update the version of `@typescript-eslint/parser` to support TypeScript 5.5.

* Change the version of `@typescript-eslint/parser` in `package.json` from `^6.7.5` to `^7.14.1`.
