### PR TITLE
fix: remove `preinstall` script

### DIFF
--- a/.changeset/breezy-socks-serve.md
+++ b/.changeset/breezy-socks-serve.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+fix: remove `preinstall` script

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "prettier-eslint"
   ],
   "scripts": {
-    "preinstall": "npx only-allow npm",
     "prepare": "simple-git-hooks",
     "start": "nps",
     "test": "nps test"
@@ -72,7 +71,6 @@
     "jest": "^29.7.0",
     "nps": "^5.10.0",
     "nps-utils": "^1.7.0",
-    "only-allow": "^1.2.1",
     "prettier-eslint-cli": "^8.0.1",
     "prettier-plugin-pkg": "^0.19.0",
     "prettier-plugin-svelte": "^3.3.3",


### PR DESCRIPTION
close #1175
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `preinstall` script and `only-allow` dependency from `package.json`.
> 
>   - **Scripts**:
>     - Remove `preinstall` script from `package.json` which enforced npm usage via `npx only-allow npm`.
>   - **Dependencies**:
>     - Remove `only-allow` from `devDependencies` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fprettier-eslint&utm_source=github&utm_medium=referral)<sup> for 7a5e675e3378b6a4f53cadde5f3f3c97556e87ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->