### PR TITLE
fix: `tslib` should be listed as `dependency`

### DIFF
--- a/.changeset/ready-mangos-run.md
+++ b/.changeset/ready-mangos-run.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+fix: `tslib` should be listed as `dependency`

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier": "^3.5.3",
     "pretty-format": "^29.7.0",
     "require-relative": "^0.8.7",
+    "tslib": "^2.8.1",
     "vue-eslint-parser": "^9.4.3"
   },
   "devDependencies": {
@@ -99,7 +100,6 @@
     "strip-indent": "^3.0.0",
     "svelte": "^4.2.19",
     "svelte-eslint-parser": "^0.33.1",
-    "tslib": "^2.8.1",
     "typescript": "^5.8.3"
   },
   "resolutions": {


### PR DESCRIPTION
Fixes MODULE_NOT_FOUND error when used in a non-ts project

I think this is all it takes, but I'm really not a javascript guy.

fixes #1185
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `tslib` to `dependencies` in `package.json` to fix `MODULE_NOT_FOUND` error in non-TypeScript projects.
> 
>   - **Dependencies**:
>     - Move `tslib` from `devDependencies` to `dependencies` in `package.json` to fix `MODULE_NOT_FOUND` error in non-TypeScript projects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fprettier-eslint&utm_source=github&utm_medium=referral)<sup> for 52ee63bb52cbdeae99bc39bc6d2190d9504053f9. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to improve application stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->