### PR TITLE
fix: use `overrideConfigFile: true` + `overrideConfig` instead

### DIFF
--- a/.changeset/late-eels-march.md
+++ b/.changeset/late-eels-march.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+fix: use `overrideConfigFile: true` + `overrideConfig` instead

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,8 @@ function createPrettify(formatOptions: PrettierOptions, prettierPath: string) {
 
 function createEslintFix(eslintConfig: ESLintConfig, eslintPath: string) {
   return async function eslintFix(text: string, filePath?: string) {
+    eslintConfig.overrideConfigFile = true;
+
     eslintConfig.overrideConfig = {
       languageOptions: eslintConfig.languageOptions,
       rules: eslintConfig.rules,
@@ -246,8 +248,8 @@ function createEslintFix(eslintConfig: ESLintConfig, eslintPath: string) {
     delete eslintConfig.plugins;
     delete eslintConfig.settings;
 
-    // FIXME: Seems to be an ESLint core issue: `Key "plugins": Cannot redefine plugin`
-    delete eslintConfig.overrideConfig.plugins;
+    // FIXME: Seems like a bug in eslint - https://github.com/eslint/eslint/issues/19722
+    delete eslintConfig.overrideConfig.plugins!['@'];
 
     const eslint = await getESLint(eslintPath, eslintConfig);
     try {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/unbound-method, sonarjs/no-commented-code */
+/* eslint-disable @typescript-eslint/unbound-method */
 
 // eslint-disable-next-line unicorn/prefer-node-protocol -- mocked
 import fsMock_ from 'fs';
@@ -131,7 +131,7 @@ const tests: Array<{
   {
     title: 'without a filePath and no config',
     input: { text: defaultInputText() },
-    output: prettierLastOutput(),
+    output: noopOutput(),
   },
   {
     title: 'inferring bracketSpacing',
@@ -187,7 +187,7 @@ const tests: Array<{
         languageOptions: { globals: { windows: 'writable' } },
       },
     },
-    output: prettierLastOutput(),
+    output: noopOutput(),
   },
   {
     title: 'CSS example',
@@ -284,7 +284,7 @@ const tests: Array<{
         },
       },
     },
-    output: "var foo = { bar: 'baz' };",
+    output: 'var foo = { bar: "baz" };',
   },
 ];
 
@@ -524,14 +524,14 @@ function defaultInputText() {
   `;
 }
 
-// function noopOutput() {
-//   return `
-//     function foo() {
-//       // stuff
-//       console.log("Hello world!", and, stuff);
-//     }
-//   `;
-// }
+function noopOutput() {
+  return `
+    function foo() {
+      // stuff
+      console.log("Hello world!", and, stuff);
+    }
+  `;
+}
 
 function defaultOutput() {
   return `


### PR DESCRIPTION
related https://github.com/eslint/eslint/issues/19722
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `overrideConfigFile` to `true` and adjust `overrideConfig` in `createEslintFix` to address ESLint issue #19722.
> 
>   - **Behavior**:
>     - In `createEslintFix` in `index.ts`, set `eslintConfig.overrideConfigFile` to `true`.
>     - Modify `eslintConfig.overrideConfig` to include `languageOptions`, `rules`, `ignores`, `plugins`, and `settings`.
>     - Delete `eslintConfig.overrideConfig.plugins!['@']` to address ESLint issue #19722.
>   - **Tests**:
>     - Update `index.spec.ts` to reflect changes in ESLint configuration handling.
>     - Change expected output in several test cases to match new behavior.
>     - Remove `sonarjs/no-commented-code` disable comment in `index.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fprettier-eslint&utm_source=github&utm_medium=referral)<sup> for 520166ca89dfbe4e39bf881013ac865372e7bd8b. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of ESLint configuration overrides to ensure proper application and compatibility with specific plugin keys.

- **Tests**
  - Updated test cases to reflect changes in expected formatting results.
  - Activated and refined a helper function for generating no-operation output in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->