### PR TITLE
fix: key ESLint caches on the effective cwd

### DIFF
--- a/.changeset/eslint-cache-cwd.md
+++ b/.changeset/eslint-cache-cwd.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+Include the effective `cwd` in the ESLint instance and config cache keys, so a `process.cwd()` change no longer returns an entry resolved for a different directory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,7 @@ function getESLintApiOptions(eslintConfig: ESLintConfig): ESLintConfig {
   return {
     ignore: eslintConfig.ignore ?? true,
     allowInlineConfig: eslintConfig.allowInlineConfig ?? true,
-    cwd: eslintConfig.cwd,
+    cwd: eslintConfig.cwd ?? process.cwd(),
     baseConfig: eslintConfig.baseConfig,
     overrideConfig: eslintConfig.overrideConfig,
     overrideConfigFile: eslintConfig.overrideConfigFile,
@@ -358,8 +358,8 @@ async function getESLintConfig(
   eslintPath: string,
   eslintConfig: ESLintConfig,
 ): Promise<ESLintConfig> {
-  const configPath = filePath || process.cwd();
   const configOptions = getESLintApiOptions(eslintConfig);
+  const configPath = filePath || configOptions.cwd;
   const cacheKey = hash({ filePath, eslintPath, configOptions });
   const cachedConfig = eslintConfigCache.get(cacheKey);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -679,7 +679,11 @@ export async function getESLint(
   eslintPath: string,
   eslintOptions: ESLintOptions,
 ) {
-  const cacheKey = hash({ eslintPath, eslintOptions });
+  const options = {
+    ...eslintOptions,
+    cwd: eslintOptions.cwd ?? process.cwd(),
+  };
+  const cacheKey = hash({ eslintPath, eslintOptions: options });
   const cachedESLint = eslintCache.get(cacheKey);
 
   if (cachedESLint) {
@@ -691,7 +695,7 @@ export async function getESLint(
     'eslint',
   );
   try {
-    const eslint = new ESLint(eslintOptions);
+    const eslint = new ESLint(options);
     eslintCache.set(cacheKey, eslint);
     return eslint;
   } catch (error) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -550,6 +550,67 @@ test('caches eslint configs with equivalent options', async () => {
   expect(eslintMock.mock.calculateConfigForFile).toHaveBeenCalledTimes(1);
 });
 
+test('does not reuse cached eslint instances across effective cwds', async () => {
+  const eslintPath = path.join(__dirname, '../__mocks__/eslint.ts');
+  const cwdSpy = vi.spyOn(process, 'cwd');
+
+  cwdSpy.mockReturnValue(path.join(__dirname, 'fixtures'));
+  const eslint = await getESLint(eslintPath, { fix: true });
+
+  cwdSpy.mockReturnValue(path.join(__dirname, 'fixtures/paths'));
+  const otherESLint = await getESLint(eslintPath, { fix: true });
+
+  cwdSpy.mockRestore();
+
+  expect(otherESLint).not.toBe(eslint);
+  expect(eslintMock.ESLint).toHaveBeenCalledTimes(2);
+});
+
+test('does not reuse cached eslint configs across effective cwds', async () => {
+  const fixturePath = path.join(
+    __dirname,
+    'fixtures/effective-cwd-default-config.js',
+  );
+  const cwdSpy = vi.spyOn(process, 'cwd');
+
+  cwdSpy.mockReturnValue(path.resolve(__dirname, '..'));
+  await format({ text: defaultInputText(), filePath: fixturePath });
+
+  cwdSpy.mockReturnValue(__dirname);
+  await format({ text: defaultInputText(), filePath: fixturePath });
+
+  cwdSpy.mockRestore();
+
+  expect(eslintMock.mock.calculateConfigForFile).toHaveBeenCalledTimes(2);
+});
+
+test('reuses cached eslint configs when an explicit cwd is given', async () => {
+  const fixturePath = path.join(
+    __dirname,
+    'fixtures/explicit-cwd-default-config.js',
+  );
+  const eslintConfig = { cwd: path.resolve(__dirname, '..') };
+  const cwdSpy = vi.spyOn(process, 'cwd');
+
+  cwdSpy.mockReturnValue(path.join(__dirname, 'fixtures'));
+  await format({
+    text: defaultInputText(),
+    filePath: fixturePath,
+    eslintConfig,
+  });
+
+  cwdSpy.mockReturnValue(path.join(__dirname, 'fixtures/paths'));
+  await format({
+    text: defaultInputText(),
+    filePath: fixturePath,
+    eslintConfig: { ...eslintConfig },
+  });
+
+  cwdSpy.mockRestore();
+
+  expect(eslintMock.mock.calculateConfigForFile).toHaveBeenCalledTimes(1);
+});
+
 test('uses caller eslint config on config cache hit', async () => {
   const fixturePath = path.resolve(
     './mock/cache-override-test-default-config.js',


### PR DESCRIPTION
## Summary

The ESLint instance and config caches added in #1214 hash the supplied options, but ESLint falls back to `process.cwd()` when `cwd` is omitted, so the effective working directory never reached either cache key. Two calls made from different working directories could therefore share an entry that ESLint would have resolved differently. Closes #1220.

## Changes

`getESLint` defaults `cwd` to `process.cwd()` and uses that normalized object for both the cache key and the ESLint constructor. `getESLintApiOptions` applies the same default, so the resolved config cache key and `calculateConfigForFile` both see the effective directory, and the trace log reuses it rather than reading `process.cwd()` again.

## Release impact

Patch, via changeset.

## Validation

Both regression tests fail on master and pass with the fix. The full suite reports 91 passing tests, 96.89 percent branch coverage, and a clean lint and build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESLint configuration handling when no working directory is specified.
  * Prevented cached ESLint instances and configurations from being incorrectly reused across different working directories.
  * Ensured equivalent explicit and default working-directory settings share cached configurations consistently.

* **Tests**
  * Added coverage for cache behavior across implicit and explicit working-directory settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->